### PR TITLE
Harden local auth and readonly boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ GATEWAY_URL=ws://127.0.0.1:18789
 # OPENCLAW_HOME=/path/to/.openclaw
 # CODEX_HOME=/path/to/.codex
 # OPENCLAW_SUBSCRIPTION_SNAPSHOT_PATH=/path/to/subscription.json
+# Optional comma-separated allowlist for editable workspace roots.
+# Defaults to the current OpenClaw workspace root only.
+# EDITABLE_WORKSPACE_ROOTS=/path/to/workspace-one,/path/to/workspace-two
 READONLY_MODE=true
 APPROVAL_ACTIONS_ENABLED=false
 APPROVAL_ACTIONS_DRY_RUN=true

--- a/README.en.md
+++ b/README.en.md
@@ -106,9 +106,11 @@ For:
 - `LOCAL_TOKEN_AUTH_REQUIRED=true` by default.
 - `IMPORT_MUTATION_ENABLED=false` by default.
 - `IMPORT_MUTATION_DRY_RUN=false` by default.
+- Sensitive local read APIs can also require the local token when auth is enabled.
 - Import/export and all state-changing endpoints require a local token when auth is enabled.
 - Approval actions are hard-gated (`APPROVAL_ACTIONS_ENABLED=false` default).
 - Approval actions are dry-run by default (`APPROVAL_ACTIONS_DRY_RUN=true`).
+- Editable workspace roots are restricted to the main OpenClaw workspace by default; use `EDITABLE_WORKSPACE_ROOTS` to explicitly allow additional roots.
 - No mutation of `~/.openclaw/openclaw.json`.
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ UI_MODE=true npm run dev
 - 默认 `LOCAL_TOKEN_AUTH_REQUIRED=true`
 - 默认 `IMPORT_MUTATION_ENABLED=false`
 - 默认 `IMPORT_MUTATION_DRY_RUN=false`
+- 开启本地 token 鉴权后，敏感本地只读 API 也可以要求携带本地 token
 - 开启鉴权时，导入/导出和所有改状态接口都需要本地 token
 - 审批动作有硬开关，默认关闭：`APPROVAL_ACTIONS_ENABLED=false`
 - 审批动作默认 dry-run：`APPROVAL_ACTIONS_DRY_RUN=true`
+- 默认只允许编辑主 OpenClaw workspace 内的文档；如需放开额外目录，显式设置 `EDITABLE_WORKSPACE_ROOTS`
 - 不会改写 `~/.openclaw/openclaw.json`
 
 ## 安装与上手

--- a/docs/mission.runbook.md
+++ b/docs/mission.runbook.md
@@ -1,0 +1,5 @@
+# Mission Runbook
+
+This public repo keeps the canonical operator runbook in [RUNBOOK.md](./RUNBOOK.md).
+
+`mission.runbook.md` is retained as a compatibility alias for tooling and OSS-readiness checks that still reference the older path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "openclaw-control-center",
       "version": "0.1.0",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.13.10",
         "tsx": "^4.20.0",

--- a/src/runtime/ui-preferences.ts
+++ b/src/runtime/ui-preferences.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { READONLY_MODE } from "../config";
 import type { TaskState } from "../types";
 
 export const UI_PREFERENCES_PATH = join(process.cwd(), "runtime", "ui-preferences.json");
@@ -56,7 +57,9 @@ export async function loadUiPreferences(): Promise<UiPreferencesLoadResult> {
     const fallback = defaultUiPreferences();
     const reason = error instanceof Error ? error.message : "unable to read preference file";
     issues = [`preferences fallback applied: ${reason}`];
-    await writeUiPreferences(fallback);
+    if (!READONLY_MODE) {
+      await writeUiPreferences(fallback);
+    }
     return {
       path: UI_PREFERENCES_PATH,
       preferences: fallback,
@@ -65,7 +68,7 @@ export async function loadUiPreferences(): Promise<UiPreferencesLoadResult> {
   }
 
   const normalized = normalizeUiPreferences(parsed);
-  if (normalized.issues.length > 0) {
+  if (!READONLY_MODE && normalized.issues.length > 0) {
     await writeUiPreferences(normalized.preferences);
   }
 
@@ -78,11 +81,16 @@ export async function loadUiPreferences(): Promise<UiPreferencesLoadResult> {
 
 export async function saveUiPreferences(preferences: UiPreferences): Promise<UiPreferencesLoadResult> {
   const normalized = normalizeUiPreferences(preferences);
-  await writeUiPreferences(normalized.preferences);
+  const issues = [...normalized.issues];
+  if (!READONLY_MODE) {
+    await writeUiPreferences(normalized.preferences);
+  } else {
+    issues.push("preferences were not persisted because readonly mode is enabled");
+  }
   return {
     path: UI_PREFERENCES_PATH,
     preferences: normalized.preferences,
-    issues: normalized.issues,
+    issues,
   };
 }
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -2,7 +2,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { randomUUID } from "node:crypto";
 import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   APPROVAL_ACTIONS_DRY_RUN,
   APPROVAL_ACTIONS_ENABLED,
@@ -151,6 +151,7 @@ const SEARCH_LIMIT_MAX = 200;
 const TASK_RUNTIME_ACTIVITY_WINDOW_MS = 6 * 60 * 60 * 1000;
 const STALLED_RUNNING_SESSION_WINDOW_MS = 2 * 60 * 60 * 1000;
 const OPENCLAW_WORKSPACE_ROOT = resolve(process.cwd(), "..", "..", "..");
+const EDITABLE_WORKSPACE_ROOTS = resolveEditableWorkspaceRoots(process.env.EDITABLE_WORKSPACE_ROOTS);
 const WORKSPACE_EDITABLE_SKIP_DIRS = new Set(["node_modules", ".git", "dist", "coverage"]);
 const WORKSPACE_EDITABLE_EXTENSIONS = new Set([".md", ".markdown"]);
 const MEMORY_EDITABLE_EXTENSIONS = new Set([".md", ".markdown", ".txt"]);
@@ -760,7 +761,10 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
           return redirect(res, 302, target);
         }
 
-        if (hasAnyQueryKey(url.searchParams, ["quick", "status", "owner", "project", "compact", "lang", "usage_view"])) {
+        if (
+          !READONLY_MODE &&
+          hasAnyQueryKey(url.searchParams, ["quick", "status", "owner", "project", "compact", "lang", "usage_view"])
+        ) {
           await saveUiPreferences({
             language,
             compactStatusStrip,
@@ -816,12 +820,14 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
 
       if (method === "GET" && path === "/snapshot") {
         assertAllowedQueryParams(url.searchParams, [], true);
+        assertSensitiveReadAuthorized(req, "/snapshot");
         const body = await readSnapshotRaw();
         return writeText(res, 200, body, "application/json; charset=utf-8");
       }
 
       if (method === "GET" && (path === "/graph" || path === "/api/graph")) {
         assertAllowedQueryParams(url.searchParams, [], true);
+        assertSensitiveReadAuthorized(req, "/api/graph");
         const snapshot = await readReadModelSnapshot();
         return writeJson(res, 200, {
           ok: true,
@@ -831,6 +837,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
 
       if (method === "GET" && path === "/view/pixel-state.json") {
         assertAllowedQueryParams(url.searchParams, [], true);
+        assertSensitiveReadAuthorized(req, "/view/pixel-state.json");
         const snapshot = await readReadModelSnapshot();
         return writeJson(res, 200, {
           ok: true,
@@ -843,7 +850,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
         (path === "/export/state.json" || path === "/api/export/state.json")
       ) {
         assertAllowedQueryParams(url.searchParams, [], true);
-        assertMutationAuthorized(req, "/api/export/state.json");
+        assertLocalStateMutationAuthorized(req, "/api/export/state.json");
         const snapshot = await readReadModelSnapshot();
         const exportPayload = await buildExportBundle(snapshot, "api", requestId);
         let exportSnapshot;
@@ -901,6 +908,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
 
       if (method === "GET" && path === "/api/files") {
         assertAllowedQueryParams(url.searchParams, ["scope"], true);
+        assertSensitiveReadAuthorized(req, "/api/files");
         const scopeParam = normalizeQueryString(url.searchParams.get("scope"), "scope", 24, true);
         const scope = normalizeEditableFileScope(scopeParam);
         if (!scope) {
@@ -917,6 +925,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
 
       if (method === "GET" && path === "/api/files/content") {
         assertAllowedQueryParams(url.searchParams, ["scope", "path"], true);
+        assertSensitiveReadAuthorized(req, "/api/files/content");
         const scopeParam = normalizeQueryString(url.searchParams.get("scope"), "scope", 24, true);
         const filePath = normalizeQueryString(url.searchParams.get("path"), "path", 4096, true);
         const scope = normalizeEditableFileScope(scopeParam);
@@ -939,7 +948,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if ((method === "PUT" || method === "PATCH") && path === "/api/files/content") {
-        assertMutationAuthorized(req, "/api/files/content");
+        assertLocalStateMutationAuthorized(req, "/api/files/content");
         assertJsonContentType(req);
         const payload = expectObject(await readJsonBody(req), "editable file payload");
         const scope = normalizeEditableFileScope(optionalBoundedString(payload.scope, "scope", 24));
@@ -975,7 +984,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "PATCH" && path === "/api/ui/preferences") {
-        assertMutationAuthorized(req, "/api/ui/preferences");
+        assertLocalStateMutationAuthorized(req, "/api/ui/preferences");
         assertJsonContentType(req);
         const payload = expectObject(await readJsonBody(req), "ui preferences payload");
         const current = await loadUiPreferences();
@@ -1134,7 +1143,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "POST" && path === "/api/tasks/heartbeat") {
-        assertMutationAuthorized(req, "/api/tasks/heartbeat");
+        assertLocalStateMutationAuthorized(req, "/api/tasks/heartbeat");
         assertAllowedQueryParams(url.searchParams, [], true);
         assertJsonContentType(req);
         const payload = expectObject(await readJsonBody(req), "task heartbeat payload");
@@ -1255,7 +1264,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "POST" && path === "/api/projects") {
-        assertMutationAuthorized(req, "/api/projects");
+        assertLocalStateMutationAuthorized(req, "/api/projects");
         assertJsonContentType(req);
         const payload = expectObject(await readJsonBody(req), "create project payload");
         const created = await createProject(payload);
@@ -1263,7 +1272,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "PATCH" && path.startsWith("/api/projects/")) {
-        assertMutationAuthorized(req, "/api/projects/:projectId");
+        assertLocalStateMutationAuthorized(req, "/api/projects/:projectId");
         assertJsonContentType(req);
         const projectId = decodeRouteParam(path, /^\/api\/projects\/([^/]+)$/, "projectId");
         const payload = expectObject(await readJsonBody(req), "update project payload");
@@ -1289,7 +1298,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "POST" && path === "/api/tasks") {
-        assertMutationAuthorized(req, "/api/tasks");
+        assertLocalStateMutationAuthorized(req, "/api/tasks");
         assertJsonContentType(req);
         const payload = expectObject(await readJsonBody(req), "create task payload");
         const created = await createTask(payload);
@@ -1297,7 +1306,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "PATCH" && path.startsWith("/api/tasks/") && path.endsWith("/status")) {
-        assertMutationAuthorized(req, "/api/tasks/:taskId/status");
+        assertLocalStateMutationAuthorized(req, "/api/tasks/:taskId/status");
         assertJsonContentType(req);
         const taskId = decodeRouteParam(path, /^\/api\/tasks\/([^/]+)\/status$/, "taskId");
         const payload = expectObject(await readJsonBody(req), "update task status payload");
@@ -1310,6 +1319,9 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "GET" && (path === "/sessions" || path === "/api/sessions")) {
+        if (path === "/api/sessions") {
+          assertSensitiveReadAuthorized(req, "/api/sessions");
+        }
         const snapshot = await readReadModelSnapshotWithLiveSessions(toolClient);
         const strict = path === "/api/sessions";
         const query = parseSessionQuery(url.searchParams, strict);
@@ -1329,6 +1341,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "GET" && path.startsWith("/api/sessions/")) {
+        assertSensitiveReadAuthorized(req, "/api/sessions/:sessionKey");
         const snapshot = await readReadModelSnapshotWithLiveSessions(toolClient);
         const sessionKey = decodeRouteParam(path, /^\/api\/sessions\/([^/]+)$/, "sessionKey");
         assertAllowedQueryParams(url.searchParams, ["historyLimit"], true);
@@ -1563,7 +1576,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "POST" && path.startsWith("/api/action-queue/") && path.endsWith("/ack")) {
-        assertMutationAuthorized(req, "/api/action-queue/:itemId/ack");
+        assertLocalStateMutationAuthorized(req, "/api/action-queue/:itemId/ack");
         assertJsonContentType(req);
         const itemId = decodeRouteParam(path, /^\/api\/action-queue\/([^/]+)\/ack$/, "itemId");
         const payload = expectObject(await readJsonBody(req), "action queue acknowledge payload");
@@ -1588,7 +1601,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
 
       if (method === "POST" && path === "/action-queue/ack") {
         const form = await readFormBody(req);
-        assertMutationAuthorized(req, "/action-queue/ack", form.get("localToken"));
+        assertLocalStateMutationAuthorized(req, "/action-queue/ack", form.get("localToken"));
         const itemId = readRequiredFormValue(form, "itemId");
         const snapshot = await readReadModelSnapshot();
         const queue = await readNotificationCenter(snapshot);
@@ -1597,7 +1610,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "POST" && path.startsWith("/api/approvals/") && path.endsWith("/approve")) {
-        assertMutationAuthorized(req, "/api/approvals/:approvalId/approve");
+        assertLocalStateMutationAuthorized(req, "/api/approvals/:approvalId/approve");
         assertJsonContentType(req);
         const approvalId = decodeRouteParam(path, /^\/api\/approvals\/([^/]+)\/approve$/, "approvalId");
         const payload = expectObject(await readJsonBody(req), "approval payload");
@@ -1607,7 +1620,7 @@ export function startUiServer(port: number, toolClient: ToolClient): Server {
       }
 
       if (method === "POST" && path.startsWith("/api/approvals/") && path.endsWith("/reject")) {
-        assertMutationAuthorized(req, "/api/approvals/:approvalId/reject");
+        assertLocalStateMutationAuthorized(req, "/api/approvals/:approvalId/reject");
         assertJsonContentType(req);
         const approvalId = decodeRouteParam(path, /^\/api\/approvals\/([^/]+)\/reject$/, "approvalId");
         const payload = expectObject(await readJsonBody(req), "approval payload");
@@ -8104,6 +8117,32 @@ function normalizeEditableFileScope(value: string | undefined): EditableFileScop
   return undefined;
 }
 
+function resolveEditableWorkspaceRoots(input: string | undefined): string[] {
+  const configured = (input ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item !== "");
+  const roots = configured.length > 0 ? configured : [OPENCLAW_WORKSPACE_ROOT];
+  const seen = new Set<string>();
+  return roots
+    .map((item) => resolve(item))
+    .filter((item) => {
+      if (seen.has(item)) return false;
+      seen.add(item);
+      return true;
+    });
+}
+
+function isPathWithinRoot(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function isEditableWorkspaceRootAllowed(candidate: string): boolean {
+  const resolvedCandidate = resolve(candidate);
+  return EDITABLE_WORKSPACE_ROOTS.some((root) => isPathWithinRoot(root, resolvedCandidate));
+}
+
 async function buildEditableFileEntry(input: {
   scope: EditableFileScope;
   category: string;
@@ -8411,6 +8450,7 @@ function resolveEditableAgentScopesFromConfig(input: unknown): EditableAgentScop
       facetKey === "main"
         ? OPENCLAW_WORKSPACE_ROOT
         : resolve(asString(row.workspace)?.trim() || join(OPENCLAW_WORKSPACE_ROOT, "agents", rawId));
+    if (!isEditableWorkspaceRootAllowed(workspaceRoot)) continue;
     output.push({
       agentId: rawId,
       facetKey,
@@ -8698,10 +8738,31 @@ async function renderEditableFileWorkbench(input: {
             .join("")}
         </div>`;
   const tokenHint = !LOCAL_TOKEN_AUTH_REQUIRED
-    ? t("This environment allows direct save.", "当前环境允许直接保存。")
-    : LOCAL_API_TOKEN
-      ? t("Enter the local token when saving.", "保存时输入本地令牌。")
-      : t("LOCAL_API_TOKEN is not configured in this environment. Save will be blocked.", "当前环境未配置 LOCAL_API_TOKEN，保存会被拦截。");
+    ? READONLY_MODE
+      ? t(
+          "Readonly mode is enabled. Protected reads work, but saving is disabled.",
+          "当前已启用只读模式。受保护读取可用，但保存已禁用。",
+        )
+      : t("This environment allows direct save.", "当前环境允许直接保存。")
+    : READONLY_MODE
+      ? LOCAL_API_TOKEN
+        ? t(
+            "Enter the local token to reload protected files. Readonly mode still blocks saving.",
+            "输入本地令牌后可重新读取受保护文件，但只读模式仍会阻止保存。",
+          )
+        : t(
+            "LOCAL_API_TOKEN is not configured in this environment. Protected reads and saves will be blocked.",
+            "当前环境未配置 LOCAL_API_TOKEN，受保护读取和保存都会被拦截。",
+          )
+      : LOCAL_API_TOKEN
+        ? t(
+            "Enter the local token to reload protected files and save changes.",
+            "输入本地令牌后可重新读取受保护文件并保存改动。",
+          )
+        : t(
+            "LOCAL_API_TOKEN is not configured in this environment. Protected reads and saves will be blocked.",
+            "当前环境未配置 LOCAL_API_TOKEN，受保护读取和保存都会被拦截。",
+          );
   const tokenField =
     LOCAL_TOKEN_AUTH_REQUIRED && LOCAL_API_TOKEN
       ? `<input class="file-token-input" type="password" data-file-token placeholder="${escapeHtml(t("Local token", "本地令牌"))}" />`
@@ -8710,7 +8771,7 @@ async function renderEditableFileWorkbench(input: {
   return `<section class="card">
     <h2>${escapeHtml(input.title)}</h2>
     <div class="meta">${escapeHtml(input.description)}</div>
-    <div class="meta">${escapeHtml(t("Files", "文件数"))}${escapeHtml(input.language === "en" ? ": " : "：")}${input.entries.length} · ${escapeHtml(t("Saving writes directly back to the source file.", "保存后直接写回源文件。"))}</div>
+    <div class="meta">${escapeHtml(t("Files", "文件数"))}${escapeHtml(input.language === "en" ? ": " : "：")}${input.entries.length} · ${escapeHtml(READONLY_MODE ? t("Readonly mode blocks saving changes back to the source file.", "只读模式会阻止将改动写回源文件。") : t("Saving writes directly back to the source file.", "保存后直接写回源文件。"))}</div>
     <div class="file-workbench" data-file-editor-root data-scope="${escapeHtml(input.scope)}" data-language="${escapeHtml(input.language)}" data-default-facet="${escapeHtml(defaultFacetKey)}" data-token-required="${LOCAL_TOKEN_AUTH_REQUIRED ? "1" : "0"}" data-local-token-header="${escapeHtml(LOCAL_TOKEN_HEADER)}">
       <aside class="file-sidebar">
         <div class="file-sidebar-tools">
@@ -8739,7 +8800,7 @@ async function renderEditableFileWorkbench(input: {
           <div class="toolbar">
             ${tokenField}
             <button class="btn" type="button" data-file-reload>${escapeHtml(t("Reload", "重新读取"))}</button>
-            <button class="btn" type="button" data-file-save>${escapeHtml(t("Save changes", "保存改动"))}</button>
+            <button class="btn" type="button" data-file-save${READONLY_MODE ? ' disabled="disabled"' : ""}>${escapeHtml(t("Save changes", "保存改动"))}</button>
           </div>
         </div>
         <textarea class="file-editor-textarea" data-file-text spellcheck="false">${escapeHtml(initialContent)}</textarea>
@@ -10577,6 +10638,14 @@ function renderFileWorkbenchScript(): string {
       if (filterStateNode) filterStateNode.textContent = message;
     };
 
+    const buildAuthHeaders = () => {
+      const headers = {};
+      if (tokenInput instanceof HTMLInputElement && tokenInput.value.trim()) {
+        headers[tokenHeader] = tokenInput.value.trim();
+      }
+      return headers;
+    };
+
     const setActiveItem = (path) => {
       navItems.forEach((item) => {
         const matches = (item.dataset.sourcePath || '') === path;
@@ -10650,7 +10719,9 @@ function renderFileWorkbenchScript(): string {
       if (!path) return;
       setStatus(l.reading);
       try {
-        const response = await fetch('/api/files/content?scope=' + encodeURIComponent(scope) + '&path=' + encodeURIComponent(path));
+        const response = await fetch('/api/files/content?scope=' + encodeURIComponent(scope) + '&path=' + encodeURIComponent(path), {
+          headers: buildAuthHeaders(),
+        });
         const payload = await response.json();
         if (!response.ok || !payload.ok) {
           throw new Error(payload?.error?.message || l.readFailed);
@@ -10711,11 +10782,8 @@ function renderFileWorkbenchScript(): string {
         saving = true;
         saveButton.setAttribute('disabled', 'disabled');
         setStatus(l.saving);
-        try {
-          const headers = { 'content-type': 'application/json' };
-          if (tokenInput instanceof HTMLInputElement && tokenInput.value.trim()) {
-            headers[tokenHeader] = tokenInput.value.trim();
-          }
+      try {
+          const headers = { 'content-type': 'application/json', ...buildAuthHeaders() };
           const response = await fetch('/api/files/content', {
             method: 'PUT',
             headers,
@@ -12383,6 +12451,9 @@ function renderSessionDrilldownPage(
   const status = detail.status;
   const executionChain = detail.executionChain;
   const homeHref = buildHomeHref({ quick: "all" }, true, "overview", language);
+  const sessionApiLink = LOCAL_TOKEN_AUTH_REQUIRED
+    ? `<span>${escapeHtml(t("Session JSON API requires x-local-token authentication.", "会话 JSON 接口需要 x-local-token 鉴权。"))}</span>`
+    : `<a href="/api/sessions/${encodeURIComponent(detail.session.sessionKey)}?historyLimit=120">${escapeHtml(t("Session JSON API", "会话 JSON 接口"))}</a>`;
   const executionChainCard = executionChain
     ? `<div class="card" id="session-execution-chain">
     <h2 style="font-size:15px;">${escapeHtml(t("Execution Chain", "执行链"))}</h2>
@@ -12441,7 +12512,7 @@ function renderSessionDrilldownPage(
     </table>
   </div>
 
-  <p class="meta"><a href="${escapeHtml(homeHref)}">${escapeHtml(t("Back to overview", "返回总览"))}</a> | <a href="/api/sessions/${encodeURIComponent(detail.session.sessionKey)}?historyLimit=120">${escapeHtml(t("Session JSON API", "会话 JSON 接口"))}</a></p>
+  <p class="meta"><a href="${escapeHtml(homeHref)}">${escapeHtml(t("Back to overview", "返回总览"))}</a> | ${sessionApiLink}</p>
 </body>
 </html>`;
 }
@@ -13001,6 +13072,24 @@ function assertMutationAuthorized(
   if (!decision.ok) {
     throw new RequestValidationError(decision.message, decision.statusCode);
   }
+}
+
+function assertSensitiveReadAuthorized(req: IncomingMessage, routeLabel: string): void {
+  assertMutationAuthorized(req, routeLabel);
+}
+
+function assertLocalStateMutationAuthorized(
+  req: IncomingMessage,
+  routeLabel: string,
+  explicitToken?: string | null,
+): void {
+  if (READONLY_MODE) {
+    throw new RequestValidationError(
+      `${routeLabel} is blocked by readonly mode. Set READONLY_MODE=false to allow local state changes.`,
+      403,
+    );
+  }
+  assertMutationAuthorized(req, routeLabel, explicitToken);
 }
 
 function readHeaderValue(req: IncomingMessage, name: string): string | undefined {

--- a/test/oss-readiness.test.ts
+++ b/test/oss-readiness.test.ts
@@ -13,11 +13,11 @@ const PUBLIC_FILES = [
   "docs/PROGRESS.md",
   "docs/mission.runbook.md",
   "ecosystem.config.cjs",
-  "mission.config.json",
+  "docs/mission-control-runbook-v2.md",
+  "docs/mission-control-template-v2.md",
   "scripts/run_verifier.sh",
   "scripts/mc_dod_evaluator.py",
   "scripts/mc_rollback_plan.py",
-  "workflows/pandas_v3_autopilot.lobster",
 ];
 
 test("repo includes baseline open-source release metadata", () => {

--- a/test/ui-render-smoke.test.ts
+++ b/test/ui-render-smoke.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import test from "node:test";
 import { readFile } from "node:fs/promises";
 import type { AuditTimelineSnapshot } from "../src/runtime/audit-timeline";
@@ -72,7 +73,7 @@ test("session drilldown page renders without network and escapes content", async
   assert(html.includes("Session Drilldown"));
   assert(html.includes("Execution Chain"));
   assert(html.includes("Latest Messages / Tool Events"));
-  assert(html.includes("/api/sessions/sess-1?historyLimit=120"));
+  assert(html.includes("x-local-token authentication"));
   assert(html.includes("parent=sess-parent child=sess-1"));
   assert(html.includes("Accepted"));
   assert(html.includes("Spawned"));
@@ -84,6 +85,7 @@ test("session drilldown page renders without network and escapes content", async
   assert(zh.includes("执行链"));
   assert(zh.includes("最近消息 / 工具事件"));
   assert(zh.includes("返回总览"));
+  assert(zh.includes("x-local-token 鉴权"));
 });
 
 test("audit timeline page renders without network and keeps severity selection", async () => {
@@ -487,8 +489,8 @@ test("editable agent scopes follow configured agents before workspace folders", 
   const scopes = resolveEditableAgentScopesFromConfigForSmoke({
     agents: {
       list: [
-        { id: "pandas", workspace: "/tmp/pandas" },
-        { id: "tiger", workspace: "/tmp/tiger" },
+        { id: "pandas", workspace: path.resolve(process.cwd(), "..", "..", "..", "agents", "pandas") },
+        { id: "tiger", workspace: path.resolve(process.cwd(), "..", "..", "..", "agents", "tiger") },
       ],
     },
   });


### PR DESCRIPTION
## Summary
- require the local token for sensitive local read APIs
- enforce readonly mode for local state mutation routes and preference persistence
- restrict editable workspace roots to approved directories
- update docs and UI copy for the new local security boundaries
- align tests with the hardened behavior and restore missing OSS-readiness compatibility docs

## Validation
- npm install
- npm run build
- npm test