### PR TITLE
fix: correct test to reference existing docs/RUNBOOK.md

### DIFF
--- a/test/oss-readiness.test.ts
+++ b/test/oss-readiness.test.ts
@@ -11,7 +11,7 @@ const PUBLIC_FILES = [
   "README.md",
   "docs/ARCHITECTURE.md",
   "docs/PROGRESS.md",
-  "docs/mission.runbook.md",
+  "docs/RUNBOOK.md",
   "ecosystem.config.cjs",
   "mission.config.json",
   "scripts/run_verifier.sh",


### PR DESCRIPTION
## Summary

The test in `test/oss-readiness.test.ts` references a missing file `docs/mission.runbook.md` which doesn't exist in the repository.

## Changes

- Updated test to reference `docs/RUNBOOK.md` which actually exists in the repo

## Impact

- Fixes `npm test` failure on fresh clones

Fixes #4