### PR TITLE
fix: use shell mode on Windows for openclaw CLI execution

### DIFF
--- a/src/clients/openclaw-live-client.ts
+++ b/src/clients/openclaw-live-client.ts
@@ -371,6 +371,7 @@ async function runText(
   const { stdout } = await execFileAsync("openclaw", args, {
     timeout: options?.timeoutMs ?? 20_000,
     maxBuffer: options?.maxBuffer ?? 2 * 1024 * 1024,
+    shell: process.platform === "win32",
   });
   return stdout;
 }

--- a/src/runtime/openclaw-cli-insights.ts
+++ b/src/runtime/openclaw-cli-insights.ts
@@ -438,6 +438,7 @@ async function runOpenClawJson(
     const { stdout } = await execFileAsync("openclaw", args, {
       timeout: options?.timeoutMs ?? INSIGHT_COMMAND_TIMEOUT_MS,
       maxBuffer: INSIGHT_COMMAND_MAX_BUFFER,
+      shell: process.platform === "win32",
     });
     return parseEmbeddedJson(stdout) ?? fallback;
   } catch (error) {


### PR DESCRIPTION
## Summary

Closes #29

On Windows, `openclaw` is installed as a `.cmd` batch file. Node.js `execFile` cannot execute `.cmd` files directly — it requires `shell: true` to spawn through `cmd.exe`.

Without this fix, all CLI-based status checks (Gateway, Config, session history) fail silently on Windows, causing the Control Center to show panels as "blocked".

## Changes

Added `shell: process.platform === 'win32'` to both `execFile` call sites:

| File | Function | Purpose |
|------|----------|---------|
| `src/runtime/openclaw-cli-insights.ts` | `runOpenClawJson()` | Gateway status, config, security audit, update status, memory status |
| `src/clients/openclaw-live-client.ts` | `runOpenClawCli()` | Session history retrieval |

## Platform impact

- **Windows**: Fixes all CLI execution failures
- **Linux/macOS**: No change (`shell` option is `undefined`, same behavior as before)