### PR TITLE
fix: show shared workspace files under all agents, not just the first

### DIFF
--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -9556,7 +9556,7 @@ async function listEditableMemoryFiles(): Promise<EditableFileEntry[]> {
 
   const append = async (entry: EditableFileEntry | undefined): Promise<void> => {
     if (!entry) return;
-    const key = resolve(entry.sourcePath);
+    const key = `${entry.facetKey ?? ""}::${resolve(entry.sourcePath)}`;
     if (seen.has(key)) return;
     seen.add(key);
     output.push(entry);
@@ -9653,7 +9653,7 @@ async function listEditableWorkspaceFiles(): Promise<EditableFileEntry[]> {
 
   const append = async (entry: EditableFileEntry | undefined): Promise<void> => {
     if (!entry) return;
-    const key = resolve(entry.sourcePath);
+    const key = `${entry.facetKey ?? ""}::${resolve(entry.sourcePath)}`;
     if (seen.has(key)) return;
     seen.add(key);
     output.push(entry);


### PR DESCRIPTION
## Summary

Closes #2

When two agents share the same workspace directory, the Memory Workbench and Workspace Workbench only show files under the first agent. The second agent shows "no matching files".

## Root cause

`listEditableMemoryFiles()` and `listEditableWorkspaceFiles()` deduplicate entries by `resolve(sourcePath)` alone. When agents share a workspace, the same physical path is claimed by the first agent and skipped for all subsequent agents.

## Fix

Include the `facetKey` (agent identifier) in the dedup key:

```typescript
// Before — only one agent can claim each path
const key = resolve(entry.sourcePath);

// After — each agent gets its own copy
const key = \`\${entry.facetKey ?? ''}::\${resolve(entry.sourcePath)}\`;
```

Now shared files appear under **every agent** that references them, while true duplicates (same agent, same path) are still deduplicated.

## Changes

- `src/ui/server.ts`: Updated dedup key in both `listEditableMemoryFiles()` and `listEditableWorkspaceFiles()`