### PR TITLE
perf: skip slow CLI fallback when session file is missing

### DIFF
--- a/src/clients/openclaw-live-client.ts
+++ b/src/clients/openclaw-live-client.ts
@@ -61,6 +61,7 @@ const FALLBACK_ACTIVE_RECENCY_WINDOW_MS = 45 * 60 * 1000;
 const SESSION_HISTORY_TAIL_MIN_LINES = 80;
 const SESSION_HISTORY_TAIL_LINE_MULTIPLIER = 8;
 const SESSION_HISTORY_TAIL_CHUNK_BYTES = 64 * 1024;
+const SESSION_HISTORY_RECOVERY_TIMEOUT_MS = 1_500;
 
 /**
  * Live read client using official OpenClaw CLI JSON outputs.
@@ -145,36 +146,13 @@ export class OpenClawLiveClient implements ToolClient {
     if (sessionFile) {
       const fromFile = await readSessionHistoryFile(sessionFile, limit);
       if (fromFile) return fromFile;
-      // If sessionFile was provided but unreadable (e.g. ENOENT), return empty
-      // immediately instead of falling through to slow CLI commands that each
-      // block for ~14 seconds.  The file path is authoritative — when it does
-      // not exist on disk there is nothing useful the CLI can add.
-      return { rawText: "" };
+      // Cached/session-store file paths can go stale. Try a bounded CLI
+      // recovery path before giving up so we do not silently swallow history.
+      return readSessionHistoryFromCli(sessionKey, limit, {
+        timeoutMs: SESSION_HISTORY_RECOVERY_TIMEOUT_MS,
+      });
     }
-    const attempts: string[][] = [
-      ["sessions", "history", sessionKey, "--json", "--limit", String(limit)],
-      ["sessions", "history", sessionKey, "--limit", String(limit), "--json"],
-      ["sessions", "history", sessionKey, "--json"],
-    ];
-
-    for (const args of attempts) {
-      try {
-        const json = await runJson<Record<string, unknown>>(args);
-        return {
-          json,
-          rawText: JSON.stringify(json),
-        };
-      } catch {
-        continue;
-      }
-    }
-
-    try {
-      const rawText = await runHistoryText(sessionKey, limit);
-      return normalizeRawHistoryText(rawText, limit);
-    } catch {
-      return { rawText: "" };
-    }
+    return readSessionHistoryFromCli(sessionKey, limit);
   }
 
   async cronList(): Promise<CronListResponse> {
@@ -381,14 +359,49 @@ async function runText(
   return stdout;
 }
 
-async function runHistoryText(sessionKey: string, limit: number): Promise<string> {
+async function readSessionHistoryFromCli(
+  sessionKey: string,
+  limit: number,
+  options?: { timeoutMs?: number },
+): Promise<SessionsHistoryResponse> {
+  const attempts: string[][] = [
+    ["sessions", "history", sessionKey, "--json", "--limit", String(limit)],
+    ["sessions", "history", sessionKey, "--limit", String(limit), "--json"],
+    ["sessions", "history", sessionKey, "--json"],
+  ];
+
+  for (const args of attempts) {
+    try {
+      const json = await runJson<Record<string, unknown>>(args, { timeoutMs: options?.timeoutMs });
+      return {
+        json,
+        rawText: JSON.stringify(json),
+      };
+    } catch {
+      continue;
+    }
+  }
+
   try {
-    return await runText(["sessions", "history", sessionKey, "--limit", String(limit)]);
+    const rawText = await runHistoryText(sessionKey, limit, options);
+    return normalizeRawHistoryText(rawText, limit);
+  } catch {
+    return { rawText: "" };
+  }
+}
+
+async function runHistoryText(
+  sessionKey: string,
+  limit: number,
+  options?: { timeoutMs?: number; maxBuffer?: number },
+): Promise<string> {
+  try {
+    return await runText(["sessions", "history", sessionKey, "--limit", String(limit)], options);
   } catch (error) {
     if (!isUnknownLimitOptionError(error)) throw error;
   }
 
-  const rawText = await runText(["sessions", "history", sessionKey]);
+  const rawText = await runText(["sessions", "history", sessionKey], options);
   const trimmed = rawText.trim();
   if (trimmed === "") return rawText;
   const lines = trimmed.split(/\r?\n/);

--- a/test/openclaw-live-client-history.test.ts
+++ b/test/openclaw-live-client-history.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import test from "node:test";
 import { OpenClawLiveClient } from "../src/clients/openclaw-live-client";
 
@@ -10,6 +10,37 @@ function attachSessionFile(client: OpenClawLiveClient, sessionKey: string, sessi
     sessionCache: Map<string, { sessionFile?: string }>;
   };
   internalClient.sessionCache.set(sessionKey, { sessionFile });
+}
+
+async function installFakeOpenClawCli(tempDir: string, logPath: string, stdout: string): Promise<string> {
+  const binDir = join(tempDir, "bin");
+  await mkdir(binDir, { recursive: true });
+
+  const runnerPath = join(binDir, "openclaw-runner.js");
+  await writeFile(
+    runnerPath,
+    [
+      "#!/usr/bin/env node",
+      "const fs = require('node:fs');",
+      `fs.appendFileSync(${JSON.stringify(logPath)}, process.argv.slice(2).join(' ') + '\\n');`,
+      `process.stdout.write(${JSON.stringify(stdout)});`,
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(runnerPath, 0o755);
+
+  const unixShimPath = join(binDir, "openclaw");
+  await writeFile(unixShimPath, await readFile(runnerPath, "utf8"), "utf8");
+  await chmod(unixShimPath, 0o755);
+
+  const windowsShimPath = join(binDir, "openclaw.cmd");
+  await writeFile(
+    windowsShimPath,
+    `@echo off\r\n"${process.execPath}" "${runnerPath}" %*\r\n`,
+    "utf8",
+  );
+
+  return binDir;
 }
 
 test("sessionsHistory reads recent history from large cached session files", async () => {
@@ -64,6 +95,39 @@ test("sessionsHistory keeps the last line when the history file has no trailing 
     );
     assert.equal(response.rawText.trim().split("\n").length, 2);
   } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("sessionsHistory uses bounded CLI recovery when a cached session file path is stale", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "openclaw-history-"));
+  const originalPath = process.env.PATH;
+  try {
+    const sessionKey = "agent:main:demo";
+    const cliLogPath = join(tempDir, "cli.log");
+    const binDir = await installFakeOpenClawCli(
+      tempDir,
+      cliLogPath,
+      JSON.stringify({
+        history: [{ kind: "message", role: "assistant", content: "from-cli", timestamp: "2026-03-16T12:00:00.000Z" }],
+      }),
+    );
+    process.env.PATH = `${binDir}${delimiter}${originalPath ?? ""}`;
+
+    const client = new OpenClawLiveClient();
+    attachSessionFile(client, sessionKey, join(tempDir, "missing-session.jsonl"));
+
+    const response = await client.sessionsHistory({ sessionKey, limit: 2 });
+    const history = Array.isArray(response.json?.history) ? response.json.history : [];
+
+    assert.deepEqual(
+      history.map((item) => (typeof item === "string" ? item : item.content)),
+      ["from-cli"],
+    );
+    const cliLog = await readFile(cliLogPath, "utf8");
+    assert.match(cliLog, new RegExp(`sessions history ${sessionKey}`));
+  } finally {
+    process.env.PATH = originalPath;
     await rm(tempDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Problem

Fixes #28 / Ref #21

Page load is extremely slow (CPU spike, freeze, fan spinning) because the session history reader falls through to **3 CLI command attempts** when a session file doesn't exist on disk. Each CLI call blocks for **~14 seconds**, and this is triggered **multiple times** during page rendering (session-preview, tool activity, view-models).

Total blocking time per page load: **42+ seconds per session × multiple sessions = minutes of freeze**.

## Root Cause

In `sessionsHistory()`, when `sessionFile` is known but the file is missing (ENOENT):

```
readSessionHistoryFile(sessionFile) → undefined
↓ falls through to:
CLI attempt 1 (sessions history --json --limit N)  → ~14s block
CLI attempt 2 (sessions history --limit N --json)  → ~14s block  
CLI attempt 3 (sessions history --json)            → ~14s block
CLI attempt 4 (runHistoryText)                     → ~14s block
```

## Fix

When `sessionFile` is provided but unreadable, return empty history **immediately** — the file path is authoritative, so there's nothing useful the CLI fallback can add.

```typescript
if (sessionFile) {
  const fromFile = await readSessionHistoryFile(sessionFile, limit);
  if (fromFile) return fromFile;
  // Fast-fail: don't cascade to slow CLI commands
  return { rawText: '' };
}
```

The CLI fallback is preserved for sessions that have **no known file path** at all.

## Impact

- Page load: **minutes → instant** for sessions with missing history files
- CPU usage: eliminates repeated 14s CLI command spawns
- No behavior change for sessions with valid history files

## Testing

- Build passes (`npm run build`)
- All 102 tests pass (`npm test`)