### PR TITLE
实现局部页面加载优化，消除导航切换时的白屏闪烁 Implement partial page loading to eliminate white flash on navigation

### DIFF
--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -16220,7 +16220,39 @@ function renderAgentVisualEnhancerScript(): string {
     });
   });
 
-  if (motionActors.length === 0) return;
+  const initAvatars = (avatarEls) => {
+    avatarEls.forEach((avatar, index) => {
+      const canvas = avatar.querySelector('.agent-pixel-canvas');
+      if (!canvas) return;
+      if (motionActors.some((a) => a.canvas === canvas)) return;
+      const accent = getComputedStyle(avatar).getPropertyValue('--agent-accent').trim() || '#4e79a7';
+      const animal = (avatar.dataset.animal || 'default').trim().toLowerCase();
+      motionActors.push({
+        canvas,
+        accent,
+        animal,
+        seed: hashSeed(animal + ':' + accent + ':' + String(motionActors.length + 1)),
+        disabled: false,
+      });
+      // 立即渲染一帧
+      render(canvas, animal, accent, { bob: 0, sway: 0, blink: 0 });
+    });
+  };
+
+  if (motionActors.length === 0) {
+    // 即使没有头像也要监听局部导航事件，因为新页面可能有头像
+    document.addEventListener('partial-navigation-complete', () => {
+      const newAvatars = Array.from(document.querySelectorAll('.agent-avatar, .staff-avatar'));
+      initAvatars(newAvatars);
+    });
+    return;
+  }
+
+  // 监听局部导航完成事件，重新初始化新的头像
+  document.addEventListener('partial-navigation-complete', () => {
+    const newAvatars = Array.from(document.querySelectorAll('.agent-avatar, .staff-avatar'));
+    initAvatars(newAvatars);
+  });
 
   if (prefersReducedMotion) {
     motionActors.forEach((actor) => {


### PR DESCRIPTION
之前切换tab有点闪眼睛，这个PR是为了避免重新渲染页面

更改内容 / Changes:
- 添加CSS过渡效果，为中间栏和右侧栏添加淡入淡出动画 Add CSS transitions for fade in/out animations on main panel and sidebar
- 修改现有点击监听器，跳过导航链接让新逻辑处理 Modify existing click listener to skip nav-links for new handler
- 添加局部导航逻辑：拦截导航点击，用fetch获取新页面，只更新中间栏和右侧栏内容 Add partial navigation: intercept nav clicks, fetch new page, update only main and sidebar
- 同步导航链接的激活状态到当前页面 Sync navigation link active state to current page
- 处理浏览器后退/前进按钮 Handle browser back/forward buttons
------------------------------------------
**效果**
修改前：
![修改前](https://github.com/user-attachments/assets/b9a196d4-3a76-4e2a-8bb7-1164f9702300)
https://github.com/user-attachments/assets/b9a196d4-3a76-4e2a-8bb7-1164f9702300
更新后：
![修改后](https://github.com/user-attachments/assets/3ef95fcf-9683-4eb3-b646-1dd1afb7862f)
https://github.com/user-attachments/assets/3ef95fcf-9683-4eb3-b646-1dd1afb7862f
