### PR TITLE
fix: improve gateway status detection and add official dashboard link

### DIFF
--- a/src/runtime/openclaw-cli-insights.ts
+++ b/src/runtime/openclaw-cli-insights.ts
@@ -144,10 +144,15 @@ export function summarizeOpenClawConnection(statusJson: unknown, gatewayJson: un
   }).length;
   const hasRuntimeSnapshot = sessions !== undefined || statusAgents !== undefined || asString(statusRoot.runtimeVersion) !== undefined;
 
-  const gatewayRunning = asBoolean(gatewayRpc?.ok) === true || asString(gatewayRuntime?.status) === "running";
+  const gatewayRunning =
+    asBoolean(gatewayRpc?.ok) === true ||
+    asString(gatewayRuntime?.status) === "running" ||
+    asString(gatewayRuntime?.state) === "active" ||
+    (asBoolean(gatewayService?.loaded) === true && gatewayRuntime !== undefined);
   const gatewayStatus: OpenClawInsightStatus = gatewayRunning ? "ok" : "blocked";
+  const gatewayProbeUrl = asString(gatewayMeta?.probeUrl);
   const gatewayDetail = gatewayRunning
-    ? `${asString(gatewayMeta?.probeUrl) ?? "Gateway"}`
+    ? `${gatewayProbeUrl ?? "Gateway"}`
     : "Gateway is not reachable";
   const gatewayValue = gatewayRunning ? "Connected" : "Unavailable";
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -3293,6 +3293,9 @@ function renderOpenClawConnectionCard(
       <a class="btn" href="${escapeHtml(buildHomeHref({ quick: "all" }, true, "settings", language))}">${escapeHtml(
         pickUiText(language, "Open settings", "查看设置"),
       )}</a>
+      <a class="btn" href="https://app.openclaw.ai" target="_blank" rel="noopener noreferrer">${escapeHtml(
+        pickUiText(language, "OpenClaw Dashboard ↗", "OpenClaw 官方面板 ↗"),
+      )}</a>
     </div>
     <div class="status-strip">
       <div class="status-chip"><span>${escapeHtml(pickUiText(language, "Healthy links", "已接通"))}</span><strong>${connectedCount}/${rows.length}</strong></div>


### PR DESCRIPTION
## Summary

Closes #30

## Problem

Gateway displays as 'Unavailable' in the UI even when it's actually running. This happens when the `openclaw gateway status --json` output has `rpc.ok` or `service.runtime.status` missing, but the gateway is detectable through other fields.

## Changes

### 1. Broader gateway detection (`openclaw-cli-insights.ts`)

Added fallback checks for gateway running state:

```typescript
// Before: only checked two conditions
const gatewayRunning = asBoolean(gatewayRpc?.ok) === true || asString(gatewayRuntime?.status) === "running";

// After: also checks runtime.state and service.loaded
const gatewayRunning =
  asBoolean(gatewayRpc?.ok) === true ||
  asString(gatewayRuntime?.status) === "running" ||
  asString(gatewayRuntime?.state) === "active" ||
  (asBoolean(gatewayService?.loaded) === true && gatewayRuntime !== undefined);
```

### 2. Official dashboard link (`server.ts`)

Added an 'OpenClaw Dashboard ↗' button in the connection health section that links to `https://app.openclaw.ai`, giving users quick access to the official web panel.