### PR TITLE
perf: limit session-preview concurrency and increase render cache TTL

### DIFF
--- a/src/runtime/session-conversations.ts
+++ b/src/runtime/session-conversations.ts
@@ -176,6 +176,9 @@ const MAX_TOOL_SEGMENT_CHARS = 280;
 const KNOWN_ROLE_TYPES = new Set(["user", "assistant", "system", "tool"]);
 const SESSION_HISTORY_CACHE_TTL_MS = 15_000;
 
+/** Maximum concurrent session history fetches to avoid overwhelming the gateway. */
+const SESSION_HISTORY_CONCURRENCY = 4;
+
 interface SessionHistoryCacheEntry {
   limit: number;
   expiresAt: number;
@@ -199,8 +202,7 @@ export async function listSessionConversations(
   const start = (page - 1) * pageSize;
   const paged = sessions.slice(start, start + pageSize);
 
-  const items = await Promise.all(
-    paged.map(async (session) => {
+  const items = await mapWithConcurrency(paged, SESSION_HISTORY_CONCURRENCY, async (session) => {
       const history = await readSessionHistory(input.client, session.sessionKey, historyLimit);
       const latest = pickLatestMessage(history.messages);
       return {
@@ -216,8 +218,7 @@ export async function listSessionConversations(
         executionChain: inferSessionExecutionChain(session, history.messages),
         interSessionSignals: extractInterSessionSignals(history.messages),
       };
-    }),
-  );
+    });
 
   return {
     generatedAt: new Date().toISOString(),
@@ -1065,4 +1066,28 @@ function asObject(v: unknown): Record<string, unknown> | undefined {
 
 function asString(v: unknown): string | undefined {
   return typeof v === "string" ? v : undefined;
+}
+
+/**
+ * Map an array with limited concurrency to avoid overwhelming the gateway
+ * with too many parallel requests (prevents CPU spikes and timeouts).
+ */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let index = 0;
+
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const i = index++;
+      results[i] = await fn(items[i]);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
 }

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -164,7 +164,7 @@ const DOC_HUB_DIR_CANDIDATES = [
   { dir: join(process.cwd(), "runtime", "evidence"), category: "证据报告" },
 ];
 const DOC_HUB_CHAT_INDEX_PATH = join(process.cwd(), "runtime", "doc-hub-chat.json");
-const HTML_HEAVY_CACHE_TTL_MS = 3_000;
+const HTML_HEAVY_CACHE_TTL_MS = 8_000;
 const HTML_USAGE_CACHE_TTL_MS = 10_000;
 const HTML_SNAPSHOT_CACHE_TTL_MS = 10_000;
 const HTML_LIVE_SESSIONS_CACHE_TTL_MS = POLLING_INTERVALS_MS.sessionsList;


### PR DESCRIPTION
## Summary

Addresses #36 (and related closed #42) — reduces CPU spikes and render latency in session-preview.

## Root Cause

Session preview renders 12 sessions with `Promise.all`, firing 12 parallel `readSessionHistory` API calls to the gateway simultaneously. Combined with a 3-second HTML cache TTL, this causes:
- CPU spikes from concurrent gateway requests
- Repeated heavy HTML re-renders on rapid page navigation
- 4-10 second render times reported by users

## Changes

### 1. Concurrency limiter (`session-conversations.ts`)

Added `mapWithConcurrency()` helper that caps parallel session history fetches at 4 (down from unbounded 12):

```typescript
const SESSION_HISTORY_CONCURRENCY = 4;
const items = await mapWithConcurrency(paged, SESSION_HISTORY_CONCURRENCY, async (session) => { ... });
```

### 2. Cache TTL increase (`server.ts`)

Increased `HTML_HEAVY_CACHE_TTL_MS` from 3s to 8s to reduce redundant re-renders during rapid navigation.

## Impact

- **Before**: 12 simultaneous API calls → CPU spike → 4-10s render
- **After**: 4 concurrent calls max → smoother CPU usage → cached renders for 8s