### PR TITLE
Add subagent monitoring dashboard section

### DIFF
--- a/src/adapters/openclaw-readonly.ts
+++ b/src/adapters/openclaw-readonly.ts
@@ -18,6 +18,7 @@ import { loadProjectStore } from "../runtime/project-store";
 import { computeProjectSummaries } from "../runtime/project-summary";
 import { loadTaskStore } from "../runtime/task-store";
 import { computeTasksSummary } from "../runtime/task-summary";
+import { inferSubagentStatsFromKeys } from "../runtime/subagent-tree";
 
 /**
  * Official-first adapter (read path only).
@@ -72,6 +73,8 @@ export class OpenClawReadonlyAdapter {
       });
     }
 
+    const subagentStats = inferSubagentStatsFromKeys(sessions, statuses);
+
     return {
       sessions,
       statuses,
@@ -82,6 +85,7 @@ export class OpenClawReadonlyAdapter {
       tasks,
       tasksSummary,
       budgetSummary,
+      subagentStats,
       generatedAt: new Date().toISOString(),
     };
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,8 @@ export const TASK_HEARTBEAT_MAX_TASKS_PER_RUN = parsePositiveInt(
   3,
 );
 
+export const SUBAGENT_MAX_DEPTH_WARN = parsePositiveInt(process.env.SUBAGENT_MAX_DEPTH_WARN, 5);
+
 export const POLLING_INTERVALS_MS = {
   sessionsList: 5000,
   sessionStatus: 2000,

--- a/src/runtime/commander.ts
+++ b/src/runtime/commander.ts
@@ -1,4 +1,5 @@
 import { listTasks } from "./task-store";
+import { SUBAGENT_MAX_DEPTH_WARN } from "../config";
 import type {
   AlertLevel,
   BudgetEvaluation,
@@ -18,7 +19,9 @@ export interface CommanderAlert {
     | "HAS_BLOCKED"
     | "HAS_PENDING_APPROVALS"
     | "HAS_OVER_BUDGET"
-    | "HAS_TASKS_DUE";
+    | "HAS_TASKS_DUE"
+    | "HAS_SUBAGENT_ERRORS"
+    | "HAS_DEEP_CHAIN";
   message: string;
   route: "timeline" | "operator-watch" | "action-queue";
 }
@@ -79,6 +82,26 @@ export function commanderAlerts(snapshot: ReadModelSnapshot): CommanderAlert[] {
       message: `${exceptions.counts.tasksDue} task(s) are due.`,
       route: routeForLevel("warn"),
     });
+  }
+
+  if (snapshot.subagentStats) {
+    const stats = snapshot.subagentStats;
+    if (stats.errorNodes > 0) {
+      alerts.push({
+        level: "action-required",
+        code: "HAS_SUBAGENT_ERRORS",
+        message: `${stats.errorNodes} subagent session(s) are in error state.`,
+        route: routeForLevel("action-required"),
+      });
+    }
+    if (stats.maxDepth >= SUBAGENT_MAX_DEPTH_WARN) {
+      alerts.push({
+        level: "warn",
+        code: "HAS_DEEP_CHAIN",
+        message: `Subagent chain depth ${stats.maxDepth} exceeds threshold ${SUBAGENT_MAX_DEPTH_WARN}.`,
+        route: routeForLevel("warn"),
+      });
+    }
   }
 
   return alerts;
@@ -195,6 +218,32 @@ export function commanderExceptionsFeed(snapshot: ReadModelSnapshot): CommanderE
       route: routeForLevel("warn"),
       occurredAt: task.dueAt ?? task.updatedAt ?? fallbackOccurredAt,
     });
+  }
+
+  if (snapshot.subagentStats) {
+    const stats = snapshot.subagentStats;
+    if (stats.errorNodes > 0) {
+      items.push({
+        level: "action-required",
+        code: "SUBAGENT_ERROR",
+        source: "subagent",
+        sourceId: "subagent-tree",
+        message: `${stats.errorNodes} subagent session(s) are in error state.`,
+        route: routeForLevel("action-required"),
+        occurredAt: fallbackOccurredAt,
+      });
+    }
+    if (stats.maxDepth >= SUBAGENT_MAX_DEPTH_WARN) {
+      items.push({
+        level: "warn",
+        code: "SUBAGENT_DEEP_CHAIN",
+        source: "subagent",
+        sourceId: "subagent-tree",
+        message: `Subagent chain depth ${stats.maxDepth} exceeds threshold ${SUBAGENT_MAX_DEPTH_WARN}.`,
+        route: routeForLevel("warn"),
+        occurredAt: fallbackOccurredAt,
+      });
+    }
   }
 
   const sortedItems = [...items].sort(compareFeedItems);

--- a/src/runtime/subagent-tree.ts
+++ b/src/runtime/subagent-tree.ts
@@ -1,0 +1,213 @@
+import type { AgentRunState, ReadModelSnapshot, SessionStatusSnapshot, SessionSummary, SubagentTreeStats } from "../types";
+import type { SessionExecutionChainSummary } from "./session-conversations";
+
+export interface SubagentNode {
+  sessionKey: string;
+  agentId?: string;
+  label?: string;
+  state: AgentRunState;
+  model?: string;
+  tokensIn: number;
+  tokensOut: number;
+  totalTokens: number;
+  cost: number;
+  lastActivity?: string;
+  parentSessionKey?: string;
+  children: SubagentNode[];
+  depth: number;
+  stage: SessionExecutionChainSummary["stage"];
+}
+
+export interface SubagentTreeSnapshot {
+  roots: SubagentNode[];
+  totalNodes: number;
+  activeNodes: number;
+  idleNodes: number;
+  errorNodes: number;
+  blockedNodes: number;
+  totalCost: number;
+  totalTokens: number;
+  maxDepth: number;
+  generatedAt: string;
+}
+
+interface SessionWithChain {
+  session: SessionSummary;
+  status?: SessionStatusSnapshot;
+  executionChain?: SessionExecutionChainSummary;
+}
+
+export function buildSubagentTree(
+  sessions: SessionWithChain[],
+  snapshot: ReadModelSnapshot,
+): SubagentTreeSnapshot {
+  const statusByKey = new Map<string, SessionStatusSnapshot>();
+  for (const s of snapshot.statuses) {
+    statusByKey.set(s.sessionKey, s);
+  }
+
+  const childrenMap = new Map<string, SessionWithChain[]>();
+  const allKeys = new Set<string>();
+  const hasParent = new Set<string>();
+
+  for (const item of sessions) {
+    allKeys.add(item.session.sessionKey);
+    const parentKey = item.executionChain?.parentSessionKey;
+    if (parentKey && parentKey !== item.session.sessionKey) {
+      hasParent.add(item.session.sessionKey);
+      const list = childrenMap.get(parentKey) ?? [];
+      list.push(item);
+      childrenMap.set(parentKey, list);
+    }
+  }
+
+  const sessionByKey = new Map<string, SessionWithChain>();
+  for (const item of sessions) {
+    sessionByKey.set(item.session.sessionKey, item);
+  }
+
+  function buildNode(item: SessionWithChain, depth: number): SubagentNode {
+    const status = item.status ?? statusByKey.get(item.session.sessionKey);
+    const children = (childrenMap.get(item.session.sessionKey) ?? []).map((child) =>
+      buildNode(child, depth + 1),
+    );
+
+    return {
+      sessionKey: item.session.sessionKey,
+      agentId: item.session.agentId,
+      label: item.session.label,
+      state: item.session.state,
+      model: status?.model,
+      tokensIn: status?.tokensIn ?? 0,
+      tokensOut: status?.tokensOut ?? 0,
+      totalTokens: (status?.tokensIn ?? 0) + (status?.tokensOut ?? 0),
+      cost: status?.cost ?? 0,
+      lastActivity: item.session.lastMessageAt ?? status?.updatedAt,
+      parentSessionKey: item.executionChain?.parentSessionKey,
+      children,
+      depth,
+      stage: item.executionChain?.stage ?? "idle",
+    };
+  }
+
+  const roots: SubagentNode[] = [];
+  for (const item of sessions) {
+    if (!hasParent.has(item.session.sessionKey)) {
+      roots.push(buildNode(item, 0));
+    }
+  }
+
+  roots.sort((a, b) => {
+    const aTime = a.lastActivity ? Date.parse(a.lastActivity) : 0;
+    const bTime = b.lastActivity ? Date.parse(b.lastActivity) : 0;
+    return bTime - aTime;
+  });
+
+  const stats = collectStats(roots);
+
+  return {
+    roots,
+    ...stats,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function collectStats(nodes: SubagentNode[]): {
+  totalNodes: number;
+  activeNodes: number;
+  idleNodes: number;
+  errorNodes: number;
+  blockedNodes: number;
+  totalCost: number;
+  totalTokens: number;
+  maxDepth: number;
+} {
+  let totalNodes = 0;
+  let activeNodes = 0;
+  let idleNodes = 0;
+  let errorNodes = 0;
+  let blockedNodes = 0;
+  let totalCost = 0;
+  let totalTokens = 0;
+  let maxDepth = 0;
+
+  function walk(node: SubagentNode): void {
+    totalNodes++;
+    if (node.state === "running") activeNodes++;
+    if (node.state === "idle") idleNodes++;
+    if (node.state === "error") errorNodes++;
+    if (node.state === "blocked" || node.state === "waiting_approval") blockedNodes++;
+    totalCost += node.cost;
+    totalTokens += node.totalTokens;
+    if (node.depth > maxDepth) maxDepth = node.depth;
+    for (const child of node.children) walk(child);
+  }
+
+  for (const root of nodes) walk(root);
+
+  return { totalNodes, activeNodes, idleNodes, errorNodes, blockedNodes, totalCost, totalTokens, maxDepth };
+}
+
+export function flattenTree(roots: SubagentNode[]): SubagentNode[] {
+  const result: SubagentNode[] = [];
+  function walk(node: SubagentNode): void {
+    result.push(node);
+    for (const child of node.children) walk(child);
+  }
+  for (const root of roots) walk(root);
+  return result;
+}
+
+/**
+ * Lightweight subagent stats from session key patterns only (no history needed).
+ * Uses `:run:` marker in session keys to infer parent-child relationships.
+ */
+export function inferSubagentStatsFromKeys(
+  sessions: SessionSummary[],
+  statuses: SessionStatusSnapshot[],
+): SubagentTreeStats {
+  const RUN_MARKER = ":run:";
+  const statusByKey = new Map(statuses.map((s) => [s.sessionKey, s]));
+  const childKeys = new Set<string>();
+  let maxDepth = 0;
+
+  for (const session of sessions) {
+    let depth = 0;
+    let key = session.sessionKey;
+    while (key.includes(RUN_MARKER)) {
+      depth++;
+      const idx = key.indexOf(RUN_MARKER);
+      key = key.slice(0, idx);
+    }
+    if (depth > 0) childKeys.add(session.sessionKey);
+    if (depth > maxDepth) maxDepth = depth;
+  }
+
+  let activeNodes = 0;
+  let idleNodes = 0;
+  let errorNodes = 0;
+  let blockedNodes = 0;
+  let totalCost = 0;
+  let totalTokens = 0;
+
+  for (const session of sessions) {
+    if (session.state === "running") activeNodes++;
+    if (session.state === "idle") idleNodes++;
+    if (session.state === "error") errorNodes++;
+    if (session.state === "blocked" || session.state === "waiting_approval") blockedNodes++;
+    const status = statusByKey.get(session.sessionKey);
+    totalCost += status?.cost ?? 0;
+    totalTokens += (status?.tokensIn ?? 0) + (status?.tokensOut ?? 0);
+  }
+
+  return {
+    totalNodes: sessions.length,
+    activeNodes,
+    idleNodes,
+    errorNodes,
+    blockedNodes,
+    totalCost,
+    totalTokens,
+    maxDepth,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,17 @@ export interface BudgetPolicyConfig {
   task: Record<string, BudgetThresholds>;
 }
 
+export interface SubagentTreeStats {
+  totalNodes: number;
+  activeNodes: number;
+  idleNodes: number;
+  errorNodes: number;
+  blockedNodes: number;
+  totalCost: number;
+  totalTokens: number;
+  maxDepth: number;
+}
+
 export interface ReadModelSnapshot {
   sessions: SessionSummary[];
   statuses: SessionStatusSnapshot[];
@@ -183,6 +194,7 @@ export interface ReadModelSnapshot {
   tasks: TaskStoreSnapshot;
   tasksSummary: TasksSummary;
   budgetSummary: BudgetSummary;
+  subagentStats?: SubagentTreeStats;
   generatedAt: string;
 }
 
@@ -224,8 +236,10 @@ export interface ExceptionFeedItem {
     | "SESSION_ERROR"
     | "PENDING_APPROVAL"
     | "OVER_BUDGET"
-    | "TASK_DUE";
-  source: "system" | "session" | "approval" | "budget" | "task";
+    | "TASK_DUE"
+    | "SUBAGENT_ERROR"
+    | "SUBAGENT_DEEP_CHAIN";
+  source: "system" | "session" | "approval" | "budget" | "task" | "subagent";
   sourceId: string;
   message: string;
   route: "timeline" | "operator-watch" | "action-queue";

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -95,6 +95,7 @@ import {
   type SessionHistoryMessage,
 } from "../runtime/session-conversations";
 import { loadBestEffortAgentRoster, type AgentRosterEntry, type AgentRosterSnapshot } from "../runtime/agent-roster";
+import { buildSubagentTree, type SubagentNode, type SubagentTreeSnapshot } from "../runtime/subagent-tree";
 import {
   loadBestEffortOfficeSessionPresence,
   type OfficeSessionPresenceSnapshot,
@@ -192,6 +193,7 @@ const DASHBOARD_SECTIONS = [
   "overview",
   "calendar",
   "team",
+  "subagents",
   "memory",
   "docs",
   "usage-cost",
@@ -225,6 +227,7 @@ const DASHBOARD_SECTION_LINKS_EN: DashboardSectionLink[] = [
   { key: "overview", label: "Overview", blurb: "Today at a glance" },
   { key: "usage-cost", label: "Usage", blurb: "Budget and quota" },
   { key: "team", label: "Staff", blurb: "Mission, staff and assignments" },
+  { key: "subagents", label: "Subagents", blurb: "Subagent tree and status" },
   { key: "memory", label: "Memory", blurb: "Daily and long-term memories" },
   { key: "docs", label: "Documents", blurb: "Main and active agent core docs" },
   { key: "projects-tasks", label: "Tasks", blurb: "Board, schedule and activity" },
@@ -2417,6 +2420,9 @@ function dashboardSectionLinks(language: UiLanguage): DashboardSectionLink[] {
     if (item.key === "team") {
       return { ...item, label: "员工", blurb: "员工、分工与职责" };
     }
+    if (item.key === "subagents") {
+      return { ...item, label: "子代理", blurb: "子代理树与运行状态" };
+    }
     if (item.key === "memory") {
       return { ...item, label: "记忆", blurb: "每日与长期记忆" };
     }
@@ -3698,6 +3704,15 @@ async function renderHtml(
   const runningExecutionChainCount = taskExecutionChainCards.filter((item) => item.executionChain.stage === "running").length;
   const mappedExecutionChainCount = taskExecutionChainCards.filter((item) => !item.unmapped).length;
   const taskExecutionChainHtml = renderTaskExecutionChainCards(taskExecutionChainCards, options.language);
+  const subagentTree = buildSubagentTree(
+    taskSignalItems.map((item) => ({
+      session: { sessionKey: item.sessionKey, label: item.label, agentId: item.agentId, state: item.state, lastMessageAt: item.lastMessageAt },
+      status: snapshot.statuses.find((s) => s.sessionKey === item.sessionKey),
+      executionChain: item.executionChain,
+    })),
+    snapshot,
+  );
+  const subagentSectionHtml = renderSubagentSection(subagentTree, options.language);
   const taskRoleSummaries = buildTaskRoleSummaries(controlCenterMappingTasks);
   const pendingApprovalsCount = allApprovals.filter((item) => item.status === "pending").length;
   const inProgressTasksCount = realTasks.filter((task) => task.status === "in_progress").length;
@@ -5280,6 +5295,7 @@ async function renderHtml(
   let sectionBody = overviewSection;
   if (options.section === "calendar") sectionBody = projectsSection;
   if (options.section === "team") sectionBody = teamUnifiedSection;
+  if (options.section === "subagents") sectionBody = subagentSectionHtml;
   if (options.section === "memory") sectionBody = memorySection;
   if (options.section === "docs") sectionBody = docsSection;
   if (options.section === "usage-cost") sectionBody = usageSection;
@@ -6442,6 +6458,79 @@ async function renderHtml(
       overflow-wrap: anywhere;
       word-break: break-word;
     }
+    /* ── Subagent tree ── */
+    .subagent-summary-strip {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 10px 0;
+    }
+    .subagent-tree-container {
+      margin-top: 8px;
+      font-family: var(--mono, ui-monospace, monospace);
+      font-size: 13px;
+    }
+    .subagent-node {
+      border-left: 2px solid var(--card-border);
+      margin-left: 0;
+      padding: 2px 0;
+    }
+    .subagent-node[data-depth="0"] {
+      border-left: none;
+    }
+    .subagent-node-head {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+      padding: 4px 0;
+    }
+    .subagent-connector {
+      color: #6b6f76;
+      white-space: pre;
+      user-select: none;
+    }
+    .subagent-node-link {
+      color: var(--link, #60a5fa);
+      text-decoration: none;
+    }
+    .subagent-node-link:hover {
+      text-decoration: underline;
+    }
+    .subagent-node-meta {
+      font-size: 12px;
+      color: #6b6f76;
+      padding: 0 0 2px;
+    }
+    .subagent-children {
+      margin-left: 24px;
+    }
+    .subagent-node-error {
+      border-left-color: #ff6b6b;
+    }
+    .subagent-node-warn {
+      border-left-color: #f59e0b;
+    }
+    .subagent-node-active {
+      border-left-color: #34d399;
+    }
+    .subagent-alert {
+      padding: 8px 12px;
+      border-radius: 8px;
+      margin: 6px 0;
+      font-size: 13px;
+    }
+    .subagent-alert-error {
+      background: rgba(255, 107, 107, 0.12);
+      border: 1px solid rgba(255, 107, 107, 0.3);
+    }
+    .subagent-alert-warn {
+      background: rgba(245, 158, 11, 0.12);
+      border: 1px solid rgba(245, 158, 11, 0.3);
+    }
+    .text-ok { color: #34d399; }
+    .text-error { color: #ff6b6b; }
+    .text-warn { color: #f59e0b; }
     .timeline-summary-strip {
       margin-top: 10px;
       display: grid;
@@ -10383,6 +10472,125 @@ function renderOfficeFloor(cards: OfficeSpaceCard[], language: UiLanguage = "zh"
       )}：${items.length}</div><ul class="desk-list">${rows}</ul></section>`;
     })
     .join("")}</div>`;
+}
+
+function renderSubagentSection(tree: SubagentTreeSnapshot, language: UiLanguage = "zh"): string {
+  const t = (en: string, zh: string) => pickUiText(language, en, zh);
+  const hasNodes = tree.totalNodes > 0;
+  const hasMultiLevel = tree.roots.some((r) => r.children.length > 0);
+
+  const summaryBadges = [
+    `<span class="status-chip"><span>${escapeHtml(t("Total", "总数"))}</span><strong>${tree.totalNodes}</strong></span>`,
+    tree.activeNodes > 0
+      ? `<span class="status-chip"><span>${escapeHtml(t("Running", "运行中"))}</span><strong class="text-ok">${tree.activeNodes}</strong></span>`
+      : "",
+    tree.idleNodes > 0
+      ? `<span class="status-chip"><span>${escapeHtml(t("Idle", "空闲"))}</span><strong>${tree.idleNodes}</strong></span>`
+      : "",
+    tree.errorNodes > 0
+      ? `<span class="status-chip"><span>${escapeHtml(t("Error", "异常"))}</span><strong class="text-error">${tree.errorNodes}</strong></span>`
+      : "",
+    tree.blockedNodes > 0
+      ? `<span class="status-chip"><span>${escapeHtml(t("Blocked", "阻塞"))}</span><strong class="text-warn">${tree.blockedNodes}</strong></span>`
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const costDisplay = tree.totalCost > 0 ? `$${tree.totalCost.toFixed(4)}` : "$0";
+  const tokenDisplay = tree.totalTokens > 0 ? tree.totalTokens.toLocaleString() : "0";
+
+  const summaryPanel = `
+    <section class="card" id="subagent-summary">
+      <h2>${escapeHtml(t("Subagent status overview", "子智能体状态总览"))}</h2>
+      <div class="meta">${escapeHtml(t("Real-time view of all active sessions and their subagent spawn relationships.", "实时查看所有活跃会话及其子智能体派生关系。"))}</div>
+      <div class="subagent-summary-strip">${summaryBadges}</div>
+      <div class="meta">${escapeHtml(t("Total cost", "总费用"))}：${escapeHtml(costDisplay)} · ${escapeHtml(t("Total tokens", "总 Token"))}：${escapeHtml(tokenDisplay)} · ${escapeHtml(t("Max depth", "最大深度"))}：${tree.maxDepth}</div>
+    </section>
+  `;
+
+  const treeHtml = hasNodes
+    ? `<section class="card" id="subagent-tree">
+        <h2>${escapeHtml(t("Subagent tree", "子智能体树"))}</h2>
+        <div class="meta">${escapeHtml(t("Indentation shows parent-child relationships. Click session key to view details.", "缩进表示父子关系。点击会话 Key 可跳转查看详情。"))}</div>
+        <div class="subagent-tree-container">
+          ${tree.roots.map((root) => renderSubagentNode(root, language)).join("")}
+        </div>
+      </section>`
+    : `<section class="card" id="subagent-tree">
+        <h2>${escapeHtml(t("Subagent tree", "子智能体树"))}</h2>
+        <div class="empty-state">${escapeHtml(t("No subagent activity detected. Sessions with spawn relationships will appear here.", "暂无子智能体活动。有派生关系的会话将显示在这里。"))}</div>
+      </section>`;
+
+  const errorHighlights = hasNodes
+    ? renderSubagentExceptionHighlights(tree, language)
+    : "";
+
+  return `${summaryPanel}${treeHtml}${errorHighlights}`;
+}
+
+function renderSubagentNode(node: SubagentNode, language: UiLanguage, isLast = false): string {
+  const t = (en: string, zh: string) => pickUiText(language, en, zh);
+  const stateClass = node.state === "error" ? "subagent-node-error" : node.state === "blocked" || node.state === "waiting_approval" ? "subagent-node-warn" : node.state === "running" ? "subagent-node-active" : "";
+  const label = node.label || node.sessionKey.split(":").slice(-2).join(":");
+  const sessionHref = `/session/${encodeURIComponent(node.sessionKey)}`;
+  const costStr = node.cost > 0 ? `$${node.cost.toFixed(4)}` : "";
+  const tokenStr = node.totalTokens > 0 ? `${node.totalTokens.toLocaleString()} tok` : "";
+  const modelStr = node.model ?? "";
+  const metaParts = [modelStr, tokenStr, costStr].filter(Boolean).join(" · ");
+
+  const stateBadge = `<span class="badge ${stateBadgeClass(node.state)}">${escapeHtml(node.state)}</span>`;
+  const stageBadge = node.stage !== "idle" ? ` <span class="badge badge-${node.stage === "running" ? "ok" : "info"}">${escapeHtml(node.stage)}</span>` : "";
+
+  const childrenHtml = node.children.length > 0
+    ? `<div class="subagent-children">${node.children.map((child, idx) => renderSubagentNode(child, language, idx === node.children.length - 1)).join("")}</div>`
+    : "";
+
+  return `<div class="subagent-node ${escapeHtml(stateClass)}" data-depth="${node.depth}">
+    <div class="subagent-node-head">
+      <span class="subagent-connector">${node.depth > 0 ? (isLast ? "└── " : "├── ") : ""}</span>
+      <a class="subagent-node-link" href="${escapeHtml(sessionHref)}"><code>${escapeHtml(label)}</code></a>
+      ${stateBadge}${stageBadge}
+      ${node.agentId ? `<span class="meta">${escapeHtml(node.agentId)}</span>` : ""}
+    </div>
+    ${metaParts ? `<div class="subagent-node-meta" style="padding-left:${(node.depth + 1) * 24}px;">${escapeHtml(metaParts)}${node.lastActivity ? ` · ${escapeHtml(t("last", "最近"))} ${escapeHtml(node.lastActivity)}` : ""}</div>` : ""}
+    ${childrenHtml}
+  </div>`;
+}
+
+function stateBadgeClass(state: AgentRunState): string {
+  if (state === "running") return "badge-ok";
+  if (state === "error") return "badge-action-required";
+  if (state === "blocked" || state === "waiting_approval") return "badge-warn";
+  return "badge-idle";
+}
+
+function renderSubagentExceptionHighlights(tree: SubagentTreeSnapshot, language: UiLanguage): string {
+  const t = (en: string, zh: string) => pickUiText(language, en, zh);
+  const items: string[] = [];
+
+  if (tree.errorNodes > 0) {
+    items.push(`<div class="subagent-alert subagent-alert-error">
+      <strong>${escapeHtml(t("Error", "异常"))}</strong>：${tree.errorNodes} ${escapeHtml(t("subagent(s) in error state", "个子智能体处于异常状态"))}
+    </div>`);
+  }
+  if (tree.blockedNodes > 0) {
+    items.push(`<div class="subagent-alert subagent-alert-warn">
+      <strong>${escapeHtml(t("Blocked", "阻塞"))}</strong>：${tree.blockedNodes} ${escapeHtml(t("subagent(s) blocked or waiting approval", "个子智能体被阻塞或等待审批"))}
+    </div>`);
+  }
+  if (tree.maxDepth >= 5) {
+    items.push(`<div class="subagent-alert subagent-alert-warn">
+      <strong>${escapeHtml(t("Deep chain", "深层链路"))}</strong>：${escapeHtml(t("Max depth", "最大深度"))} ${tree.maxDepth}${escapeHtml(t(", consider reviewing the spawning strategy", "，建议检查派生策略"))}
+    </div>`);
+  }
+
+  if (items.length === 0) return "";
+
+  return `<section class="card" id="subagent-exceptions">
+    <h2>${escapeHtml(t("Subagent alerts", "子智能体告警"))}</h2>
+    ${items.join("")}
+  </section>`;
 }
 
 function renderNativeMotionScript(language: UiLanguage = "zh"): string {


### PR DESCRIPTION
## Summary
- New "Subagents" dashboard tab showing subagent tree, status overview, and exception highlights
- Build subagent tree from existing session execution chain data (parent/child relationships)
- Extend commander alerts with `HAS_SUBAGENT_ERRORS` and `HAS_DEEP_CHAIN` warnings
- Add `SUBAGENT_MAX_DEPTH_WARN` config (default 5, env var override)
- Bilingual UI (en/zh), consistent with existing styling

## Changed files
| File | Change |
|------|--------|
| `src/runtime/subagent-tree.ts` | **New** — tree builder + stats inference |
| `src/types.ts` | Add `SubagentTreeStats`, extend `ReadModelSnapshot` and exception codes |
| `src/config.ts` | Add `SUBAGENT_MAX_DEPTH_WARN` threshold |
| `src/adapters/openclaw-readonly.ts` | Populate `subagentStats` in snapshot |
| `src/runtime/commander.ts` | Subagent error and deep chain alerts |
| `src/ui/server.ts` | New nav section, tree renderer, CSS |

## Test plan
- [x] All 89 existing tests pass
- [x] TypeScript compiles with no errors
- [ ] Verify subagent tree renders correctly with live session data
- [ ] Verify exception alerts trigger on error/deep chain scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)