### PR TITLE
fix: add repo URL to inline install prompts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ Phase 1: inspect the environment
 8. Do not assume any fixed agent names. If `openclaw.json` is readable, treat it as the source of truth.
 
 Phase 2: install the project
-9. Confirm that the current directory is the control-center repo root.
+9. Confirm that the current directory is the control-center repo root. If it has not been cloned yet, clone it first: `git clone https://github.com/TianyiDataScience/openclaw-control-center.git`
 10. Verify the repo is complete before editing anything.
-11. If core paths are missing, stop and re-clone the official repo.
+11. If core paths (`src/runtime`, `src/ui`, `package.json`) are missing, do not continue. Re-clone from `https://github.com/TianyiDataScience/openclaw-control-center.git`.
 12. Run dependency install.
 13. If `.env` does not exist, create it from `.env.example`; otherwise correct it while preserving safe defaults.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -246,9 +246,9 @@ cp .env.example .env
 8. 不要假设任何固定 agent 名称。若 `openclaw.json` 可读，就以它为准。
 
 第二阶段：安装项目
-9. 确认当前目录是 control-center 仓库根目录。
+9. 确认当前目录是 control-center 仓库根目录。如果还没有 clone，先执行：`git clone https://github.com/TianyiDataScience/openclaw-control-center.git`
 10. 先确认仓库本体完整。
-11. 如果缺少 `src/runtime`、`src/ui` 或 `package.json`，不要继续安装，直接重新 clone 官方仓库。
+11. 如果缺少 `src/runtime`、`src/ui` 或 `package.json`，不要继续安装，重新 clone：`https://github.com/TianyiDataScience/openclaw-control-center.git`。
 12. 运行依赖安装。
 13. 如果 `.env` 不存在，就从 `.env.example` 创建；如果存在，就在保留安全默认值的前提下修正它。
 


### PR DESCRIPTION
## Problem

The install prompt blocks embedded in `README.md` (EN) and `README.zh-CN.md` (ZH) tell the AI agent to "re-clone the official repo" (step 11) but **never provide the actual repository URL**.

When a user copies the prompt from the README and pastes it into their OpenClaw agent, the agent has no way to locate the repo to clone. It has to ask the user for the URL, breaking the "hands-off install" flow that the prompt is designed for.

The standalone `INSTALL_PROMPT.md` and `INSTALL_PROMPT.en.md` already include the full URL — this is a parity gap in the README-embedded versions.

## Real-world failure

I hit this exact issue: my OpenClaw agent received the README install prompt, ran environment checks successfully, but then could not proceed because step 11 said "re-clone the official repo" without a URL. The agent had to stop and ask me which repo to clone.

## Changes

**README.md** (EN inline prompt):
- Step 9: added `git clone https://github.com/TianyiDataScience/openclaw-control-center.git` for first-time setup
- Step 11: replaced vague "re-clone the official repo" with the explicit URL + list of core paths to check

**README.zh-CN.md** (ZH inline prompt):
- Same changes in Chinese

No source code, tests, or `.env.example` changes. Only documentation.