### PR TITLE
fix: stabilize OpenClaw CLI insight context

### DIFF
--- a/src/clients/openclaw-live-client.ts
+++ b/src/clients/openclaw-live-client.ts
@@ -14,7 +14,12 @@ import type {
   SessionsListResponse,
 } from "../contracts/openclaw-tools";
 import { APPROVAL_ACTIONS_ENABLED } from "../config";
-import { loadCurrentAgentCatalog, resolveOpenClawHomePath } from "../runtime/current-agent-catalog";
+import {
+  buildOpenClawCliEnv,
+  loadCurrentAgentCatalog,
+  resolveOpenClawHomePath,
+  resolveOpenClawWorkspaceRootPath,
+} from "../runtime/current-agent-catalog";
 import type { ToolClient } from "./tool-client";
 
 const execFileAsync = promisify(execFile);
@@ -364,6 +369,8 @@ async function runText(
   options?: { timeoutMs?: number; maxBuffer?: number },
 ): Promise<string> {
   const { stdout } = await execFileAsync("openclaw", args, {
+    cwd: resolveOpenClawWorkspaceRootPath(),
+    env: buildOpenClawCliEnv(),
     timeout: options?.timeoutMs ?? 20_000,
     maxBuffer: options?.maxBuffer ?? 2 * 1024 * 1024,
     shell: process.platform === "win32",

--- a/src/runtime/current-agent-catalog.ts
+++ b/src/runtime/current-agent-catalog.ts
@@ -83,6 +83,27 @@ export function resolveOpenClawConfigPath(): string {
   return join(resolveOpenClawHomePath(), "openclaw.json");
 }
 
+export function resolveOpenClawWorkspaceRootPath(): string {
+  const explicit = process.env.OPENCLAW_WORKSPACE_ROOT?.trim();
+  if (explicit) return explicit;
+  return join(resolveOpenClawHomePath(), "workspace");
+}
+
+export function buildOpenClawCliEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("npm_") || key === "INIT_CWD") {
+      delete env[key];
+    }
+  }
+
+  delete env.OPENCLAW_HOME;
+  delete env.OPENCLAW_CONFIG_PATH;
+  delete env.OPENCLAW_WORKSPACE_ROOT;
+  return env;
+}
+
 function isFsNotFound(error: unknown): boolean {
   return Boolean(
     error &&

--- a/src/runtime/openclaw-cli-insights.ts
+++ b/src/runtime/openclaw-cli-insights.ts
@@ -1,11 +1,12 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { buildOpenClawCliEnv, resolveOpenClawWorkspaceRootPath } from "./current-agent-catalog";
 
 const execFileAsync = promisify(execFile);
 const INSIGHT_CACHE_TTL_MS = 15_000;
-const INSIGHT_COMMAND_TIMEOUT_MS = 4_000;
-const STATUS_COMMAND_TIMEOUT_MS = 8_000;
-const UPDATE_STATUS_COMMAND_TIMEOUT_MS = 8_000;
+const INSIGHT_COMMAND_TIMEOUT_MS = 15_000;
+const STATUS_COMMAND_TIMEOUT_MS = 15_000;
+const UPDATE_STATUS_COMMAND_TIMEOUT_MS = 15_000;
 const INSIGHT_COMMAND_MAX_BUFFER = 4 * 1024 * 1024;
 
 interface TimedSourceCache<T> {
@@ -401,24 +402,15 @@ async function loadSourceWithCache<T>(
 ): Promise<T> {
   const now = Date.now();
   if (cache && cache.expiresAt > now) return cache.value;
-  if (cache) {
-    if (!inFlight) {
-      const nextValue = loader();
-      assignInFlight(nextValue);
-      void nextValue
-        .then((value) => {
-          assignCache({
-            value,
-            expiresAt: Date.now() + INSIGHT_CACHE_TTL_MS,
-          });
-        })
-        .finally(() => {
-          assignInFlight(undefined);
-        });
+
+  if (inFlight) {
+    try {
+      return await inFlight;
+    } catch {
+      if (cache) return cache.value;
+      throw new Error("cached source refresh failed without fallback");
     }
-    return cache.value;
   }
-  if (inFlight) return inFlight;
 
   const nextValue = loader();
   assignInFlight(nextValue);
@@ -426,9 +418,12 @@ async function loadSourceWithCache<T>(
     const value = await nextValue;
     assignCache({
       value,
-      expiresAt: now + INSIGHT_CACHE_TTL_MS,
+      expiresAt: Date.now() + INSIGHT_CACHE_TTL_MS,
     });
     return value;
+  } catch (error) {
+    if (cache) return cache.value;
+    throw error;
   } finally {
     assignInFlight(undefined);
   }
@@ -441,6 +436,8 @@ async function runOpenClawJson(
 ): Promise<unknown> {
   try {
     const { stdout } = await execFileAsync("openclaw", args, {
+      cwd: resolveOpenClawWorkspaceRootPath(),
+      env: buildOpenClawCliEnv(),
       timeout: options?.timeoutMs ?? INSIGHT_COMMAND_TIMEOUT_MS,
       maxBuffer: INSIGHT_COMMAND_MAX_BUFFER,
       shell: process.platform === "win32",

--- a/test/current-agent-catalog.test.ts
+++ b/test/current-agent-catalog.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildOpenClawCliEnv, resolveOpenClawWorkspaceRootPath } from "../src/runtime/current-agent-catalog";
+
+test("resolveOpenClawWorkspaceRootPath defaults under OPENCLAW_HOME and honors explicit override", () => {
+  const originalHome = process.env.OPENCLAW_HOME;
+  const originalWorkspaceRoot = process.env.OPENCLAW_WORKSPACE_ROOT;
+
+  try {
+    process.env.OPENCLAW_HOME = "/tmp/openclaw-home";
+    delete process.env.OPENCLAW_WORKSPACE_ROOT;
+    assert.equal(resolveOpenClawWorkspaceRootPath(), "/tmp/openclaw-home/workspace");
+
+    process.env.OPENCLAW_WORKSPACE_ROOT = "/tmp/custom-workspace";
+    assert.equal(resolveOpenClawWorkspaceRootPath(), "/tmp/custom-workspace");
+  } finally {
+    if (originalHome === undefined) delete process.env.OPENCLAW_HOME;
+    else process.env.OPENCLAW_HOME = originalHome;
+    if (originalWorkspaceRoot === undefined) delete process.env.OPENCLAW_WORKSPACE_ROOT;
+    else process.env.OPENCLAW_WORKSPACE_ROOT = originalWorkspaceRoot;
+  }
+});
+
+test("buildOpenClawCliEnv strips npm pollution and OPENCLAW overrides but keeps provider secrets", () => {
+  const original = {
+    npm_config_user_agent: process.env.npm_config_user_agent,
+    INIT_CWD: process.env.INIT_CWD,
+    OPENCLAW_HOME: process.env.OPENCLAW_HOME,
+    OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
+    OPENCLAW_WORKSPACE_ROOT: process.env.OPENCLAW_WORKSPACE_ROOT,
+    JINA_API_KEY: process.env.JINA_API_KEY,
+    PATH: process.env.PATH,
+  };
+
+  try {
+    process.env.npm_config_user_agent = "npm-test-agent";
+    process.env.INIT_CWD = "/tmp/init-cwd";
+    process.env.OPENCLAW_HOME = "/tmp/override-home";
+    process.env.OPENCLAW_CONFIG_PATH = "/tmp/override-config.json";
+    process.env.OPENCLAW_WORKSPACE_ROOT = "/tmp/override-workspace";
+    process.env.JINA_API_KEY = "jina_test_key";
+
+    const env = buildOpenClawCliEnv();
+
+    assert.equal(env.npm_config_user_agent, undefined);
+    assert.equal(env.INIT_CWD, undefined);
+    assert.equal(env.OPENCLAW_HOME, undefined);
+    assert.equal(env.OPENCLAW_CONFIG_PATH, undefined);
+    assert.equal(env.OPENCLAW_WORKSPACE_ROOT, undefined);
+    assert.equal(env.JINA_API_KEY, "jina_test_key");
+    assert.equal(env.PATH, process.env.PATH);
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[key as keyof NodeJS.ProcessEnv];
+      else process.env[key as keyof NodeJS.ProcessEnv] = value;
+    }
+  }
+});


### PR DESCRIPTION
## Summary

This fixes a false-negative connection-health path in the control center when invoking `openclaw` CLI commands from the dashboard runtime.

### What changed

- run OpenClaw CLI calls from the OpenClaw workspace root instead of the repo cwd
- strip `npm_*` / `INIT_CWD` pollution from child-process env before invoking `openclaw`
- avoid injecting `OPENCLAW_*` overrides that can break plugin/config resolution on real installs
- raise CLI insight timeouts to better match slower local runtimes
- make expired insight caches await a fresh value instead of immediately serving stale blocked state
- add regression tests for workspace-root resolution and CLI env sanitization

## Why

On a real OpenClaw installation, the Settings → Connection health card could incorrectly show:

- `Gateway is not reachable`
- `openclaw.json is missing or invalid`
- `Runtime status is still loading`

…even though the local OpenClaw runtime was healthy.

The root causes were a mix of:

- invoking `openclaw` from the wrong cwd
- inheriting npm runner env pollution
- stale cache behavior returning outdated blocked summaries on the first refresh after expiry
- timeout budgets that were too aggressive for slower local CLI responses

## Validation

- `npm test` → `106/106 pass`
- verified Settings → Connection health renders healthy Gateway / Config / Runtime on a real local install
- verified LAN-access local config separately (`UI_BIND_ADDRESS=0.0.0.0`) without including that local-only change in this PR
