### PR TITLE
fix: reuse staff pixel avatar canvas for hall page

### DIFF
--- a/src/ui/collaboration-hall-theme.ts
+++ b/src/ui/collaboration-hall-theme.ts
@@ -224,16 +224,11 @@ export function renderCollaborationHallTheme(): string {
       display: grid;
       place-items: center;
     }
-    .hall-agent-avatar .hall-avatar-fallback,
     .hall-agent-avatar .agent-pixel-canvas {
       position: absolute;
       inset: 0;
       width: 100%;
       height: 100%;
-    }
-    .hall-agent-avatar .hall-avatar-fallback {
-      display: block;
-      object-fit: cover;
     }
     .hall-member-avatar,
     .hall-task-card-avatar,

--- a/src/ui/collaboration-hall.ts
+++ b/src/ui/collaboration-hall.ts
@@ -610,9 +610,14 @@ export function renderCollaborationHallClientScript(language: UiLanguage): strin
   };
   const hallAvatarMarkup = (label, className) => {
     const avatar = deriveHallAvatar(label);
-    return '<div class="' + esc(className) + ' hall-agent-avatar" style="--agent-accent:' + esc(avatar.accent) + ';" aria-hidden="true"><div class="agent-stage"><img class="agent-avatar-img hall-avatar-fallback" src="/hall-avatars/' + esc(avatar.asset) + '" alt="" loading="lazy" /></div></div>';
+    return '<div class="' + esc(className) + ' hall-agent-avatar" style="--agent-accent:' + esc(avatar.accent) + ';" data-animal="' + esc(avatar.animal) + '" aria-hidden="true"><div class="agent-stage"><canvas class="agent-pixel-canvas" width="128" height="128"></canvas></div></div>';
   };
-  const paintHallPixelAvatars = () => {};
+  const paintHallPixelAvatars = (container) => {
+    const api = window.__openclawPixelAvatar;
+    if (!api || typeof api.renderElement !== 'function') return;
+    const els = container ? Array.from(container.querySelectorAll('.hall-agent-avatar')) : [];
+    els.forEach((el) => api.renderElement(el));
+  };
 
   const setFlash = (message) => {
     if (!flash) return;
@@ -3221,7 +3226,7 @@ function initialsForName(value: string): string {
 
 function renderHallPixelAvatar(label: string, className: string): string {
   const identity = resolveHallAvatarIdentity(label);
-  return `<div class="${escapeHtml(className)} hall-agent-avatar" style="--agent-accent:${escapeHtml(identity.accent)};" aria-hidden="true"><div class="agent-stage"><img class="agent-avatar-img hall-avatar-fallback" src="/hall-avatars/${escapeHtml(identity.asset)}" alt="" loading="lazy" /></div></div>`;
+  return `<div class="${escapeHtml(className)} hall-agent-avatar" style="--agent-accent:${escapeHtml(identity.accent)};" data-animal="${escapeHtml(identity.animal)}" aria-hidden="true"><div class="agent-stage"><canvas class="agent-pixel-canvas" width="128" height="128"></canvas></div></div>`;
 }
 
 function resolveHallAvatarIdentity(input: string): { animal: string; accent: string; asset: string } {

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -240,7 +240,6 @@ const OPENCLAW_WORKSPACE_ROOT = resolveOpenClawWorkspaceRootShared({
   openclawHomeDir: OPENCLAW_HOME_DIR,
   configPath: OPENCLAW_CONFIG_PATH,
 });
-const CONTROL_CENTER_ROOT = resolveControlCenterRoot(process.cwd());
 const WORKSPACE_EDITABLE_SKIP_DIRS = new Set(["node_modules", ".git", "dist", "coverage"]);
 const WORKSPACE_EDITABLE_EXTENSIONS = new Set([".md", ".markdown"]);
 const MEMORY_EDITABLE_EXTENSIONS = new Set([".md", ".markdown", ".txt"]);
@@ -1431,11 +1430,6 @@ export function startUiServer(port: number, toolClient: ToolClient, options: Sta
         return await serveAvatarFile(res, fileName, method === "HEAD");
       }
 
-      if ((method === "GET" || method === "HEAD") && path.startsWith("/hall-avatars/")) {
-        assertAllowedQueryParams(url.searchParams, [], true);
-        const fileName = decodeURIComponent(path.slice("/hall-avatars/".length));
-        return await serveHallAvatarFile(res, fileName, method === "HEAD");
-      }
 
       if (method === "GET" && path === "/api/search/tasks") {
         const query = parseSearchQuery(url.searchParams);
@@ -16750,7 +16744,7 @@ function renderFileWorkbenchScript(): string {
 function renderAgentVisualEnhancerScript(): string {
   return `<script>
 (() => {
-  const avatars = Array.from(document.querySelectorAll('.agent-avatar, .staff-avatar'));
+  const avatars = Array.from(document.querySelectorAll('.agent-avatar, .staff-avatar, .hall-agent-avatar'));
   if (!avatars.length) return;
   const prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   // Pixel motion runs fully on client; no network polling and no extra token usage.
@@ -18957,35 +18951,6 @@ async function serveAvatarFile(res: ServerResponse, rawFileName: string, headOnl
   } catch {
     return writeApiError(res, 404, "NOT_FOUND", "Avatar file not found.");
   }
-}
-
-async function serveHallAvatarFile(res: ServerResponse, rawFileName: string, headOnly = false): Promise<void> {
-  const fileName = normalizeSafeFileName(rawFileName);
-  if (!fileName) return writeApiError(res, 404, "NOT_FOUND", "Hall avatar file not found.");
-  const filePath = join(CONTROL_CENTER_ROOT, "runtime", "exports", "staff-avatars", fileName);
-  try {
-    const buffer = await readFile(filePath);
-    res.writeHead(200, {
-      "content-type": avatarContentType(fileName),
-      "cache-control": "public, max-age=3600",
-    });
-    res.end(headOnly ? undefined : buffer);
-  } catch {
-    return writeApiError(res, 404, "NOT_FOUND", "Hall avatar file not found.");
-  }
-}
-
-function resolveControlCenterRoot(startDir: string): string {
-  const visited = new Set<string>();
-  let cursor = resolve(startDir || process.cwd());
-  while (!visited.has(cursor)) {
-    visited.add(cursor);
-    if (existsSync(join(cursor, "runtime", "exports", "staff-avatars"))) return cursor;
-    const parent = dirname(cursor);
-    if (parent === cursor) break;
-    cursor = parent;
-  }
-  return resolve(startDir || process.cwd());
 }
 
 async function writeAvatarUploadFromDataUrl(input: { dataUrl: string; fileNameHint?: string }): Promise<{ fileName: string; sizeBytes: number }> {

--- a/test/collaboration-hall-ui-smoke.test.ts
+++ b/test/collaboration-hall-ui-smoke.test.ts
@@ -21,7 +21,7 @@ test("collaboration hall renders a three-pane hall-first shell", () => {
   assert(html.includes('data-hall-create-task'));
   assert(html.includes('data-hall-handoff'));
   assert(html.match(/data-hall-toggle-context/g)?.length >= 2);
-  assert(html.includes('/hall-avatars/'));
+  assert(html.includes('agent-pixel-canvas'));
   assert(html.includes('hall-empty-actions'));
   assert(html.includes('hall-thread-subtitle'));
   const script = renderCollaborationHallClientScript("en");
@@ -90,7 +90,7 @@ test("hall chat page source wires the hall workbench into its own section", asyn
   assert(source.includes("collaborationHallWorkbench"));
   assert(source.includes("renderCollaborationHall({"));
   assert(source.includes("renderCollaborationHallClientScript(options.language)"));
-  assert(source.includes("const hallChatSection = `"));
+  assert(source.includes("const hallChatSection = needsHallChat ? `"));
   assert(source.includes("${collaborationHallWorkbench}"));
   assert(source.includes('if (options.section === "hall-chat") sectionBody = hallChatSection;'));
 });

--- a/test/ui-render-smoke.test.ts
+++ b/test/ui-render-smoke.test.ts
@@ -585,7 +585,7 @@ test("memory and workspace sections expose editable file workbenches", async () 
   assert(source.includes('const staffOverviewCards = needsTeamSnapshot'));
   assert(source.includes(".staff-brief-grid {\n      margin-top: 12px;\n      display: grid;\n      grid-template-columns: repeat(3, minmax(0, 1fr));"));
   assert(source.includes('<canvas class="agent-pixel-canvas" width="256" height="256"></canvas>'));
-  assert(source.includes("querySelectorAll('.agent-avatar, .staff-avatar')"));
+  assert(source.includes("querySelectorAll('.agent-avatar, .staff-avatar, .hall-agent-avatar')"));
   assert(source.includes('data-animal="${escapeHtml(effectiveAnimal)}"'));
   assert(source.includes('t("Shared staff mission", "员工共同目标")'));
   assert(source.includes('t("Staff system details", "员工配置明细")'));


### PR DESCRIPTION
## Summary
- Hall 页面头像显示为碎图标，因为 `<img src="/hall-avatars/xxx.png">` 引用的静态 PNG 文件从未生成
- 改为复用员工页面已有的 canvas 像素头像渲染系统（`window.__openclawPixelAvatar`）
- 清理所有相关死代码：`/hall-avatars/` 路由、`serveHallAvatarFile`、`resolveControlCenterRoot`、`.hall-avatar-fallback` CSS

## Before / After

### Before — 头像显示为碎图标
<img width="3434" height="2028" alt="image" src="https://github.com/user-attachments/assets/7f43a0a8-3fde-4a97-a651-620a27752d0a" />

### After — 像素头像正常渲染
<img width="1178" height="808" alt="image" src="https://github.com/user-attachments/assets/52ee7284-b705-4fa5-a86c-1ae38b5fcfbf" />

## Changes
- **`src/ui/collaboration-hall.ts`**: SSR 和客户端 JS 头像从 `<img>` 改为 `<canvas>` + `data-animal`；实现 `paintHallPixelAvatars` 用于动态渲染
- **`src/ui/server.ts`**: `renderAgentVisualEnhancerScript` 选择器增加 `.hall-agent-avatar`；删除死代码
- **`src/ui/collaboration-hall-theme.ts`**: 删除 `.hall-avatar-fallback` 死 CSS
- **`test/`**: 更新断言匹配新渲染方式

## Test plan
- [x] 48/49 tests pass（1 个预先存在的失败，与本次无关）
- [x] Chrome 验证群聊页头像正常渲染
- [x] Chrome 验证员工页头像无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)