### PR TITLE
fix(usage-cost): add Feishu/Webchat session type classification and fix cumulative bySessionType data source

### DIFF
--- a/src/runtime/usage-cost.ts
+++ b/src/runtime/usage-cost.ts
@@ -505,10 +505,10 @@ export function computeUsageCostSnapshot(
           runtime.sourceStatus,
           (event) => event.provider?.trim() || inferProvider(event.model),
         );
-  const bySessionType = buildSessionTypeBreakdownFromSessionContexts(
-    runtimeUsage?.sessionContexts ?? [],
-    runtime.sourceStatus,
-  );
+  const bySessionType =
+    runtime.sourceStatus === "not_connected"
+      ? buildSessionTypeBreakdownFromSessionContexts(runtimeUsage?.sessionContexts ?? [], runtime.sourceStatus)
+      : buildSessionTypeBreakdownFromRuntimeEvents(runtimeEvents30d, runtime.sourceStatus);
   const byCronJob = buildCronJobBreakdownFromSessionContexts(
     runtimeUsage?.sessionContexts ?? [],
     runtime.sourceStatus,
@@ -927,7 +927,10 @@ function resolveRuntimeUsage(
         : event.sessionId
           ? sessionById.get(event.sessionId)
           : undefined;
-      const sessionKey = event.sessionKey ?? context?.sessionKey;
+      const sessionKey =
+        event.sessionKey ??
+        context?.sessionKey ??
+        (event.agentId && event.sessionId ? `agent:${event.agentId}:orphaned:${event.sessionId}` : undefined);
       const model = event.model ?? context?.model;
       const provider = event.provider ?? context?.provider ?? inferProvider(model);
 
@@ -1272,7 +1275,7 @@ function buildSessionTypeBreakdownFromSessionContexts(
   const uniqueSessions = dedupeSessionContexts(contexts);
   if (uniqueSessions.length === 0) return [];
 
-  const order = ["Cron", "Discord", "Telegram", "Main/内部会话"] as const;
+  const order = ["Cron", "Discord", "Telegram", "Feishu", "Webchat", "其它", "Main/内部会话"] as const;
   const buckets = new Map<string, UsageBreakdownRow>(
     order.map((label) => [
       label,
@@ -1307,7 +1310,7 @@ function buildSessionTypeBreakdownFromRuntimeEvents(
   sourceStatus: ConnectionStatus,
 ): UsageBreakdownRow[] {
   if (sourceStatus === "not_connected" || events.length === 0) return [];
-  const order = ["Cron", "Discord", "Telegram", "Main/内部会话"] as const;
+  const order = ["Cron", "Discord", "Telegram", "Feishu", "Webchat", "其它", "Main/内部会话"] as const;
   const buckets = new Map<string, UsageBreakdownRow>(
     order.map((label) => [
       label,
@@ -1505,7 +1508,7 @@ function dedupeSessionContexts(contexts: RuntimeSessionContext[]): RuntimeSessio
   return [...byIdentity.values()];
 }
 
-function classifySessionTypeLabel(context: RuntimeSessionContext): "Cron" | "Discord" | "Telegram" | "Main/内部会话" {
+function classifySessionTypeLabel(context: RuntimeSessionContext): "Cron" | "Discord" | "Telegram" | "Feishu" | "Webchat" | "其它" | "Main/内部会话" {
   const key = context.sessionKey.trim().toLowerCase();
   const channel = context.channel?.trim().toLowerCase() ?? "";
   const surface = context.surface?.trim().toLowerCase() ?? "";
@@ -1529,15 +1532,26 @@ function classifySessionTypeLabel(context: RuntimeSessionContext): "Cron" | "Dis
   ) {
     return "Telegram";
   }
+  if (key.includes(":feishu:") || channel === "feishu" || surface === "feishu") {
+    return "Feishu";
+  }
+  if (key.includes(":webchat:") || channel === "webchat" || surface === "webchat") {
+    return "Webchat";
+  }
+  if (!key) {
+    return "其它";
+  }
   return "Main/内部会话";
 }
 
-function classifySessionTypeFromSessionKey(sessionKey: string | undefined): "Cron" | "Discord" | "Telegram" | "Main/内部会话" {
+function classifySessionTypeFromSessionKey(sessionKey: string | undefined): "Cron" | "Discord" | "Telegram" | "Feishu" | "Webchat" | "其它" | "Main/内部会话" {
   const key = sessionKey?.trim().toLowerCase() ?? "";
-  if (!key) return "Main/内部会话";
+  if (!key) return "其它";
   if (key.includes(":cron:") || key.startsWith("cron:")) return "Cron";
   if (key.includes(":discord:") || key.startsWith("discord:")) return "Discord";
   if (key.includes(":telegram:") || key.startsWith("telegram:")) return "Telegram";
+  if (key.includes(":feishu:")) return "Feishu";
+  if (key.includes(":webchat:")) return "Webchat";
   return "Main/内部会话";
 }
 
@@ -2570,6 +2584,16 @@ function parseSubscriptionUsage(
   const limit = isSyntheticSnapshot ? undefined : rawLimit;
   const remaining = isSyntheticSnapshot ? undefined : rawRemaining;
 
+  // Quota window fields (primary=5h, secondary=Week)
+  const primaryWindowLabel = asString(subscription.primaryWindowLabel) ?? undefined;
+  const primaryUsedPercent = asNumber(subscription.primaryUsedPercent) ?? undefined;
+  const primaryRemainingPercent = asNumber(subscription.primaryRemainingPercent) ?? undefined;
+  const primaryResetAt = asString(subscription.primaryResetAt) ?? undefined;
+  const secondaryWindowLabel = asString(subscription.secondaryWindowLabel) ?? undefined;
+  const secondaryUsedPercent = asNumber(subscription.secondaryUsedPercent) ?? undefined;
+  const secondaryRemainingPercent = asNumber(subscription.secondaryRemainingPercent) ?? undefined;
+  const secondaryResetAt = asString(subscription.secondaryResetAt) ?? undefined;
+
   const cycleStart =
     asString(subscription.cycleStart) ??
     asString(subscription.currentPeriodStart) ??
@@ -2655,6 +2679,14 @@ function parseSubscriptionUsage(
       : missingProviderFields.length === 0
         ? "provider_connected"
         : "provider_snapshot_partial",
+    primaryWindowLabel,
+    primaryUsedPercent,
+    primaryRemainingPercent,
+    primaryResetAt,
+    secondaryWindowLabel,
+    secondaryUsedPercent,
+    secondaryRemainingPercent,
+    secondaryResetAt,
   };
 }
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -7476,7 +7476,7 @@ async function renderHtml(
     </section>
     <section class="card">
       <h2>${escapeHtml(t("AI usage mix (all sessions)", "AI 用量构成（全部会话）"))}</h2>
-      <div class="meta">${escapeHtml(t("Timed jobs, Discord, Telegram, internal sessions", "定时任务、Discord、Telegram、内部会话"))}</div>
+      <div class="meta">${escapeHtml(t("Timed jobs, Feishu, Discord, Telegram, internal sessions", "定时任务、Feishu、Discord、Telegram、内部会话"))}</div>
       ${usageSessionTypeShareHtml}
     </section>
     <section class="card">


### PR DESCRIPTION
**Summary**

Fixes the "AI usage mix (all sessions)" pie chart in the Control Center where Feishu and Webchat sessions were incorrectly classified as "Main/内部会话", and the cumulative view was using stale sessions.json snapshot data instead of real jsonl history events.

**Changes**

1. Session type classification (usage-cost.ts)
   - Added Feishu, Webchat, and Orphaned (其它) to classifySessionTypeFromSessionKey() and classifySessionTypeLabel()
   - Sessions with !key (Orphaned) now return "其它" instead of incorrectly falling through to "Main/内部会话"

2. Cumulative bySessionType data source (usage-cost.ts)
   - Changed cumulative view to use real jsonl history events (runtimeEvents30d) instead of sessions.json snapshot
   - Now consistent with how byAgent, byProvider, etc. work

3. Orphaned session sessionKey inference (usage-cost.ts)
   - For jsonl events with no sessionKey, infer a sessionKey so byAgent and byProject can still attribute them

4. UI description update (server.ts)
   - Section description now includes Feishu: "定时任务、Feishu、Discord、Telegram、内部会话"

**Result**

Before (cumulative): Cron 397K tokens, Feishu 354K tokens (stale snapshot)
After: Cron 3.7M tokens, Feishu 18.3M tokens (real jsonl data)

Coverage: bySessionType sum = period 30d total (100%+)
