### PR TITLE
fix: add SOUL.md to STAFF_ROLE_EVIDENCE_FILE_CANDIDATES

### DIFF
--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -12076,10 +12076,19 @@ function extractLabeledField(input: string, labels: string[]): string | undefine
     if (!line) continue;
     const lower = line.toLowerCase();
     for (const label of labels) {
+      // Format: "Role: xxx" or "职责: xxx"
       const prefix = `${label.toLowerCase()}:`;
-      if (!lower.startsWith(prefix)) continue;
-      const value = line.slice(prefix.length).trim();
-      if (value) return value;
+      if (lower.startsWith(prefix)) {
+        const value = line.slice(prefix.length).trim();
+        if (value) return value;
+        continue;
+      }
+      // Format: "## Role xxx" or "## 职责 xxx" (markdown heading, no colon)
+      const headingPrefix = `## ${label.toLowerCase()} `;
+      if (lower.startsWith(headingPrefix)) {
+        const value = line.slice(headingPrefix.length).trim();
+        if (value) return value;
+      }
     }
   }
   return undefined;

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -276,6 +276,7 @@ const AGENT_DOCUMENT_FILE_CANDIDATES = [
 ] as const;
 const STAFF_ROLE_EVIDENCE_FILE_CANDIDATES = [
   "IDENTITY.md",
+  "SOUL.md",
   "AGENTS.md",
   "README.md",
   "MEMORY.md",


### PR DESCRIPTION
## Root Cause

The `STAFF_ROLE_EVIDENCE_FILE_CANDIDATES` array in `src/ui/server.ts` was missing `SOUL.md`. This caused the role-label resolution logic (`loadStaffRoleEvidence` / `resolveStaffRoleLabel`) to never read SOUL.md files, even when they properly defined the agent's role and responsibilities — resulting in '工作区未写明职责' errors.

## Fix

Added `"SOUL.md"` to `STAFF_ROLE_EVIDENCE_FILE_CANDIDATES` (placed second, right after IDENTITY.md, consistent with other candidate arrays like `SHARED_DOCUMENT_FILE_CANDIDATES`).

## Verification

`npm run build` passes with no errors. Compiled output confirms SOUL.md is now included in the candidate list.