### PR TITLE
fix(control-center): unblock web UI cold start and remove homepage render bottlenecks

### DIFF
--- a/WEBUI-FIX-SUMMARY-2026-04-15.md
+++ b/WEBUI-FIX-SUMMARY-2026-04-15.md
@@ -1,0 +1,132 @@
+# WebUI fix summary — 2026-04-15
+
+## Problem
+The OpenClaw Control Center web UI was timing out on `GET /` and failing `npm run smoke:ui`.
+
+Observed behavior:
+- UI smoke initially failed because the server did not become ready within 10 seconds.
+- After startup sequencing was improved, the server listened successfully, but homepage rendering still timed out.
+- `/healthz` reported `stale` during cold start because it depended on a monitor snapshot that could take tens of seconds to refresh.
+
+## Root cause
+The homepage render path was doing too much synchronous work during cold start:
+
+1. **Startup ordering blocked UI availability**
+   - `src/index.ts` awaited `runMonitorOnce(adapter)` before starting the UI server.
+   - On a runtime with ~205 sessions, the first monitor pass could take ~25–30 seconds.
+
+2. **Homepage render blocked on live runtime reads**
+   - `readReadModelSnapshotWithLiveSessions()` could synchronously wait on live session loading.
+   - `loadCachedSessionPreview()` synchronously built preview data from session histories.
+
+3. **Homepage still had a hidden heavy path after the first fixes**
+   - `buildGlobalVisibilityViewModel()` called `countRecentToolCalls()`.
+   - That path ran `listSessionConversations()` again and scanned recent session histories for up to 20 sessions.
+   - This duplicated expensive history work inside the first-page request.
+
+4. **Cold-start health checks were too strict**
+   - `/healthz` marked the app `stale` before the first background monitor pass finished.
+
+## Fixes applied
+
+### 1) Start UI before monitor
+**File:** `src/index.ts`
+
+Changed startup flow so that when `UI_MODE=true`:
+- UI server starts immediately.
+- Initial `runMonitorOnce(adapter)` runs in the background.
+
+Result:
+- Cold-start readiness is no longer blocked by a full monitor sweep.
+
+### 2) Make live sessions non-blocking on first render
+**File:** `src/ui/server.ts`
+
+Added:
+- `HTML_LIVE_SESSIONS_BLOCKING_TIMEOUT_MS = 250`
+
+Changed behavior:
+- `loadCachedLiveSessions()` now kicks off a background refresh and can return cached/empty fallback data immediately.
+- `readReadModelSnapshotWithLiveSessions()` races live session loading against a short timeout and falls back to the snapshot if live data is not ready yet.
+
+Result:
+- Homepage does not block on slow live session queries.
+
+### 3) Make session preview background-refreshable
+**File:** `src/ui/server.ts`
+
+Added:
+- `renderSessionPreviewInFlight`
+
+Changed behavior:
+- `loadCachedSessionPreview()` no longer forces a synchronous rebuild on first request.
+- It can return cached/empty fallback preview data while refreshing in the background.
+
+Result:
+- First-page render no longer waits on session-history preview construction.
+
+### 4) Remove duplicate recent tool-call history scan from homepage critical path
+**File:** `src/ui/server.ts`
+
+Changed behavior:
+- Homepage now derives `recentToolCallsCount` from already-available `taskSignalItems`.
+- `buildGlobalVisibilityViewModel()` receives `toolCallsCount` directly instead of forcing another recent-session conversation scan.
+
+Result:
+- Removed the hidden duplicated history-read bottleneck that was still causing `GET /` timeouts.
+
+### 5) Add startup grace period for healthz
+**File:** `src/runtime/healthz.ts`
+
+Added:
+- `HEALTHZ_STARTUP_GRACE_MS = 60_000`
+
+Changed behavior:
+- During the first 60 seconds of process uptime, `stale` snapshot/monitor freshness is downgraded to `warn`.
+
+Result:
+- Cold-start `/healthz` now reports a warm-up state instead of a false hard failure.
+
+### 6) Update brittle source-based test
+**File:** `test/ui-render-smoke.test.ts`
+
+Changed a hard-coded source assertion to match the new non-blocking live-session logic and assert the blocking-timeout constant.
+
+Result:
+- Tests validate the new behavior instead of the old synchronous implementation.
+
+## Validation
+
+### Manual validation
+- Homepage request returned successfully:
+  - `HTTP 200`
+  - ~`0.227s` render time during verification
+
+### Automated validation
+- `npm test -- --test-reporter=spec`
+  - **96/96 passing**
+- `npm run smoke:ui`
+  - **passed**
+
+### Health validation
+- Cold-start `/healthz` no longer hard-fails during initial warm-up.
+- It now reports `warn` instead of `stale`/503 when background monitor work has not completed yet.
+
+## Diff summary
+Files changed:
+- `src/index.ts`
+- `src/runtime/healthz.ts`
+- `src/ui/server.ts`
+- `test/ui-render-smoke.test.ts`
+
+Approximate diff:
+- 121 insertions
+- 35 deletions
+
+## Suggested commit message
+```text
+fix(control-center): unblock web UI cold start and remove homepage render bottlenecks
+```
+
+## Suggested PR summary
+This patch fixes Control Center WebUI timeouts by removing heavy synchronous work from the homepage critical path. The UI now starts before the first monitor sweep, live session and session preview reads degrade gracefully on cold start, duplicate recent tool-call history scans are removed from overview rendering, and `/healthz` now reports a startup warm-up state instead of a false stale failure.

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,17 +59,20 @@ async function start(): Promise<void> {
     return;
   }
 
-  await runMonitorOnce(adapter);
+  if (UI_MODE) {
+    startUiServer(UI_PORT, client);
+    void runMonitorOnce(adapter).catch((error) => {
+      console.error("[mission-control] initial monitor failed", error);
+    });
+  } else {
+    await runMonitorOnce(adapter);
+  }
 
   if (CONTINUOUS_MODE) {
     const intervalMs = monitorIntervalMs();
     setInterval(() => {
       void runMonitorOnce(adapter);
     }, intervalMs);
-  }
-
-  if (UI_MODE) {
-    startUiServer(UI_PORT, client);
   }
 }
 

--- a/src/runtime/healthz.ts
+++ b/src/runtime/healthz.ts
@@ -11,6 +11,7 @@ import { readMonitorLagSummary, type MonitorLagSummary } from "./monitor-health"
 
 const PACKAGE_JSON_PATH = join(process.cwd(), "package.json");
 const DIST_INDEX_PATH = join(process.cwd(), "dist", "index.js");
+const HEALTHZ_STARTUP_GRACE_MS = 60_000;
 
 type HealthStatus = "ok" | "warn" | "stale";
 
@@ -53,7 +54,10 @@ export async function buildHealthzPayload(
     computeSnapshotFreshness(snapshot, POLLING_INTERVALS_MS.sessionsList, now),
   ]);
 
-  const status = resolveOverallStatus(snapshotFreshness.status, monitor.status);
+  const inStartupGrace = process.uptime() * 1000 < HEALTHZ_STARTUP_GRACE_MS;
+  const effectiveSnapshotStatus = inStartupGrace && snapshotFreshness.status === "stale" ? "warn" : snapshotFreshness.status;
+  const effectiveMonitorStatus = inStartupGrace && monitor.status === "stale" ? "warn" : monitor.status;
+  const status = resolveOverallStatus(effectiveSnapshotStatus, effectiveMonitorStatus);
 
   return {
     generatedAt: now.toISOString(),

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -155,6 +155,7 @@ const HTML_HEAVY_CACHE_TTL_MS = 3_000;
 const HTML_USAGE_CACHE_TTL_MS = 10_000;
 const HTML_SNAPSHOT_CACHE_TTL_MS = 10_000;
 const HTML_LIVE_SESSIONS_CACHE_TTL_MS = POLLING_INTERVALS_MS.sessionsList;
+const HTML_LIVE_SESSIONS_BLOCKING_TIMEOUT_MS = 250;
 const HTML_REPLAY_CACHE_TTL_MS = 10_000;
 const JSON_MAX_BYTES = 128 * 1024;
 const FORM_MAX_BYTES = 16 * 1024;
@@ -449,6 +450,12 @@ type EditableAgentScopeConfigStatus = "configured" | "config_missing" | "config_
 
 let renderSessionPreviewCache:
   | { snapshotAt: string; value: SessionConversationListResult; expiresAt: number }
+  | undefined;
+let renderSessionPreviewInFlight:
+  | {
+      snapshotAt: string;
+      value: Promise<SessionConversationListResult>;
+    }
   | undefined;
 let renderUsageCostSummaryCache:
   | { snapshotKey: string; value: UsageCostSnapshot; expiresAt: number }
@@ -1810,37 +1817,48 @@ async function loadCachedLiveSessions(
             expiresAt: Date.now() + HTML_LIVE_SESSIONS_CACHE_TTL_MS,
           };
         })
+        .catch((error) => {
+          console.warn("[mission-control] live sessions refresh failed", error);
+        })
         .finally(() => {
           renderLiveSessionsInFlight = undefined;
         });
     }
     return renderLiveSessionsCache.value;
   }
-  if (renderLiveSessionsInFlight) {
-    return renderLiveSessionsInFlight;
+  if (!renderLiveSessionsInFlight) {
+    const nextValue = toolClient.sessionsList();
+    renderLiveSessionsInFlight = nextValue;
+    void nextValue
+      .then((value) => {
+        renderLiveSessionsCache = {
+          value,
+          expiresAt: Date.now() + HTML_LIVE_SESSIONS_CACHE_TTL_MS,
+        };
+      })
+      .catch((error) => {
+        console.warn("[mission-control] live sessions initial load failed", error);
+      })
+      .finally(() => {
+        renderLiveSessionsInFlight = undefined;
+      });
   }
 
-  const nextValue = toolClient.sessionsList();
-  renderLiveSessionsInFlight = nextValue;
-  try {
-    const value = await nextValue;
-    renderLiveSessionsCache = {
-      value,
-      expiresAt: Date.now() + HTML_LIVE_SESSIONS_CACHE_TTL_MS,
-    };
-    return value;
-  } finally {
-    renderLiveSessionsInFlight = undefined;
-  }
+  return renderLiveSessionsCache?.value ?? { sessions: [] };
 }
 
 async function readReadModelSnapshotWithLiveSessions(toolClient: ToolClient): Promise<ReadModelSnapshot> {
-  const snapshotPromise = readReadModelSnapshot();
+  const snapshot = await readReadModelSnapshot();
   const livePromise = loadCachedLiveSessions(toolClient);
 
   try {
-    const [snapshot, live] = await Promise.all([snapshotPromise, livePromise]);
-    const sessions = mapSessionsListToSummaries(live);
+    const live = await Promise.race([
+      livePromise,
+      delay(HTML_LIVE_SESSIONS_BLOCKING_TIMEOUT_MS).then(
+        () => undefined as Awaited<ReturnType<ToolClient["sessionsList"]>> | undefined,
+      ),
+    ]);
+    const sessions = live ? mapSessionsListToSummaries(live) : [];
     if (sessions.length === 0) return snapshot;
 
     const liveStatuses: ReadModelSnapshot["statuses"] = [];
@@ -3953,20 +3971,75 @@ async function loadCachedSessionPreview(snapshot: ReadModelSnapshot, toolClient:
     return renderSessionPreviewCache.value;
   }
 
-  const value = await listSessionConversations({
-    snapshot,
-    client: toolClient,
-    filters: {},
+  const buildPreview = () =>
+    listSessionConversations({
+      snapshot,
+      client: toolClient,
+      filters: {},
+      page: 1,
+      pageSize: 12,
+      historyLimit: 10,
+    });
+
+  if (renderSessionPreviewCache && renderSessionPreviewCache.snapshotAt === snapshot.generatedAt) {
+    if (!renderSessionPreviewInFlight || renderSessionPreviewInFlight.snapshotAt !== snapshot.generatedAt) {
+      const nextValue = buildPreview();
+      renderSessionPreviewInFlight = {
+        snapshotAt: snapshot.generatedAt,
+        value: nextValue,
+      };
+      void nextValue
+        .then((value) => {
+          renderSessionPreviewCache = {
+            snapshotAt: snapshot.generatedAt,
+            value,
+            expiresAt: Date.now() + HTML_HEAVY_CACHE_TTL_MS,
+          };
+        })
+        .catch((error) => {
+          console.warn("[mission-control] session preview refresh failed", error);
+        })
+        .finally(() => {
+          if (renderSessionPreviewInFlight?.snapshotAt === snapshot.generatedAt) {
+            renderSessionPreviewInFlight = undefined;
+          }
+        });
+    }
+    return renderSessionPreviewCache.value;
+  }
+
+  if (!renderSessionPreviewInFlight || renderSessionPreviewInFlight.snapshotAt !== snapshot.generatedAt) {
+    const nextValue = buildPreview();
+    renderSessionPreviewInFlight = {
+      snapshotAt: snapshot.generatedAt,
+      value: nextValue,
+    };
+    void nextValue
+      .then((value) => {
+        renderSessionPreviewCache = {
+          snapshotAt: snapshot.generatedAt,
+          value,
+          expiresAt: Date.now() + HTML_HEAVY_CACHE_TTL_MS,
+        };
+      })
+      .catch((error) => {
+        console.warn("[mission-control] session preview initial load failed", error);
+      })
+      .finally(() => {
+        if (renderSessionPreviewInFlight?.snapshotAt === snapshot.generatedAt) {
+          renderSessionPreviewInFlight = undefined;
+        }
+      });
+  }
+
+  return renderSessionPreviewCache?.value ?? {
+    generatedAt: snapshot.generatedAt,
+    total: 0,
     page: 1,
     pageSize: 12,
-    historyLimit: 10,
-  });
-  renderSessionPreviewCache = {
-    snapshotAt: snapshot.generatedAt,
-    value,
-    expiresAt: now + HTML_HEAVY_CACHE_TTL_MS,
+    filters: {},
+    items: [],
   };
-  return value;
 }
 
 function buildUsageCostCacheKey(snapshot: ReadModelSnapshot, mode: UsageCostMode): string {
@@ -4312,6 +4385,10 @@ async function renderHtml(
   const runtimeSessionIssueCount = sessionBlockedCount + sessionErrorCount + sessionWaitingApprovalCount;
   const stalledRunningSessionCount = countStalledRunningSessions(snapshot.sessions, taskSignalItems, nowMs);
   const runtimeIssueCount = runtimeSessionIssueCount + stalledRunningSessionCount;
+  const recentToolCallsCount = taskSignalItems.reduce((sum, item) => {
+    if (typeof item.toolEventCount === "number") return sum + item.toolEventCount;
+    return sum + (item.latestKind === "tool_event" ? 1 : 0);
+  }, 0);
   const globalVisibilityModel = await buildGlobalVisibilityViewModel(snapshot, toolClient, options.language, {
     cronOverview,
     openclawCronJobs,
@@ -4319,6 +4396,7 @@ async function renderHtml(
     strongTaskEvidenceCount: taskCertaintyStrongCount,
     followupTaskEvidenceCount: taskCertaintyFollowupCount,
     weakTaskEvidenceCount: taskCertaintyWeakCount,
+    toolCallsCount: recentToolCallsCount,
   });
   const attentionCount = actionQueue.counts.unacked + runtimeIssueCount + nonOkBudgets.length;
   const replayMoments = replayPreview.timeline.entries.slice(0, 8);

--- a/test/ui-render-smoke.test.ts
+++ b/test/ui-render-smoke.test.ts
@@ -333,7 +333,8 @@ test("dashboard keeps global visibility as overview-only block", async () => {
   assert(source.includes('route: "/digest/latest"'));
   assert(source.includes("void primeUiRenderCaches(toolClient);"));
   assert(source.includes("const sourceStamp = await readReadModelSourceStamp();"));
-  assert(source.includes("const sessions = mapSessionsListToSummaries(live);"));
+  assert(source.includes("const sessions = live ? mapSessionsListToSummaries(live) : [];"));
+  assert(source.includes("HTML_LIVE_SESSIONS_BLOCKING_TIMEOUT_MS = 250"));
   assert(!source.includes('state: item.active ? "running" : "idle"'));
   assert(usageSource.includes("const USAGE_SOURCE_CACHE_TTL_MS = 10_000;"));
   assert(usageSource.includes("loadCachedRuntimeUsageData()"));


### PR DESCRIPTION
# WebUI fix summary — 2026-04-15

## Problem
The OpenClaw Control Center web UI was timing out on `GET /` and failing `npm run smoke:ui`.

Observed behavior:
- UI smoke initially failed because the server did not become ready within 10 seconds.
- After startup sequencing was improved, the server listened successfully, but homepage rendering still timed out.
- `/healthz` reported `stale` during cold start because it depended on a monitor snapshot that could take tens of seconds to refresh.

## Root cause
The homepage render path was doing too much synchronous work during cold start:

1. **Startup ordering blocked UI availability**
   - `src/index.ts` awaited `runMonitorOnce(adapter)` before starting the UI server.
   - On a runtime with ~205 sessions, the first monitor pass could take ~25–30 seconds.

2. **Homepage render blocked on live runtime reads**
   - `readReadModelSnapshotWithLiveSessions()` could synchronously wait on live session loading.
   - `loadCachedSessionPreview()` synchronously built preview data from session histories.

3. **Homepage still had a hidden heavy path after the first fixes**
   - `buildGlobalVisibilityViewModel()` called `countRecentToolCalls()`.
   - That path ran `listSessionConversations()` again and scanned recent session histories for up to 20 sessions.
   - This duplicated expensive history work inside the first-page request.

4. **Cold-start health checks were too strict**
   - `/healthz` marked the app `stale` before the first background monitor pass finished.

## Fixes applied

### 1) Start UI before monitor
**File:** `src/index.ts`

Changed startup flow so that when `UI_MODE=true`:
- UI server starts immediately.
- Initial `runMonitorOnce(adapter)` runs in the background.

Result:
- Cold-start readiness is no longer blocked by a full monitor sweep.

### 2) Make live sessions non-blocking on first render
**File:** `src/ui/server.ts`

Added:
- `HTML_LIVE_SESSIONS_BLOCKING_TIMEOUT_MS = 250`

Changed behavior:
- `loadCachedLiveSessions()` now kicks off a background refresh and can return cached/empty fallback data immediately.
- `readReadModelSnapshotWithLiveSessions()` races live session loading against a short timeout and falls back to the snapshot if live data is not ready yet.

Result:
- Homepage does not block on slow live session queries.

### 3) Make session preview background-refreshable
**File:** `src/ui/server.ts`

Added:
- `renderSessionPreviewInFlight`

Changed behavior:
- `loadCachedSessionPreview()` no longer forces a synchronous rebuild on first request.
- It can return cached/empty fallback preview data while refreshing in the background.

Result:
- First-page render no longer waits on session-history preview construction.

### 4) Remove duplicate recent tool-call history scan from homepage critical path
**File:** `src/ui/server.ts`

Changed behavior:
- Homepage now derives `recentToolCallsCount` from already-available `taskSignalItems`.
- `buildGlobalVisibilityViewModel()` receives `toolCallsCount` directly instead of forcing another recent-session conversation scan.

Result:
- Removed the hidden duplicated history-read bottleneck that was still causing `GET /` timeouts.

### 5) Add startup grace period for healthz
**File:** `src/runtime/healthz.ts`

Added:
- `HEALTHZ_STARTUP_GRACE_MS = 60_000`

Changed behavior:
- During the first 60 seconds of process uptime, `stale` snapshot/monitor freshness is downgraded to `warn`.

Result:
- Cold-start `/healthz` now reports a warm-up state instead of a false hard failure.

### 6) Update brittle source-based test
**File:** `test/ui-render-smoke.test.ts`

Changed a hard-coded source assertion to match the new non-blocking live-session logic and assert the blocking-timeout constant.

Result:
- Tests validate the new behavior instead of the old synchronous implementation.

## Validation

### Manual validation
- Homepage request returned successfully:
  - `HTTP 200`
  - ~`0.227s` render time during verification

### Automated validation
- `npm test -- --test-reporter=spec`
  - **96/96 passing**
- `npm run smoke:ui`
  - **passed**

### Health validation
- Cold-start `/healthz` no longer hard-fails during initial warm-up.
- It now reports `warn` instead of `stale`/503 when background monitor work has not completed yet.

## Diff summary
Files changed:
- `src/index.ts`
- `src/runtime/healthz.ts`
- `src/ui/server.ts`
- `test/ui-render-smoke.test.ts`

Approximate diff:
- 121 insertions
- 35 deletions

## Suggested commit message
```text
fix(control-center): unblock web UI cold start and remove homepage render bottlenecks
```

## Suggested PR summary
This patch fixes Control Center WebUI timeouts by removing heavy synchronous work from the homepage critical path. The UI now starts before the first monitor sweep, live session and session preview reads degrade gracefully on cold start, duplicate recent tool-call history scans are removed from overview rendering, and `/healthz` now reports a startup warm-up state instead of a false stale failure.
