### PR TITLE
feat: local resident deployment — launchd auto-start, staff page partial refresh, avatar animation fix

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,6 +108,7 @@ npm run dev:ui
 - 推荐用 `npm run dev:ui` 启动界面；它比 `UI_MODE=true npm run dev` 更稳，尤其是 Windows shell。
 - `npm run dev` 只会执行一次 monitor，不会启动 HTTP UI。
 - 如果你要在 macOS 上把它作为长期常驻服务运行，建议配合 `~/Library/LaunchAgents/` 做自启动与崩溃自动拉起；仓库里的 `ecosystem.config.cjs` 也可用于 PM2 常驻模式。
+- 如果修改了 `src/` 下的代码，但页面看起来还是旧版本，通常不是浏览器缓存，而是常驻进程还没重启。macOS 下请重启对应 LaunchAgent（例如 `launchctl kickstart -k gui/$(id -u)/com.gary.openclaw-control-center`）后再验证。
 - 如果你所在网络屏蔽 GitHub 22 端口，Git 远端建议改成 `ssh://git@ssh.github.com:443/<owner>/<repo>.git`，避免后续更新或提交时出现“偶发断联”。
 
 ## 分区功能说明

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -107,6 +107,8 @@ npm run dev:ui
 说明：
 - 推荐用 `npm run dev:ui` 启动界面；它比 `UI_MODE=true npm run dev` 更稳，尤其是 Windows shell。
 - `npm run dev` 只会执行一次 monitor，不会启动 HTTP UI。
+- 如果你要在 macOS 上把它作为长期常驻服务运行，建议配合 `~/Library/LaunchAgents/` 做自启动与崩溃自动拉起；仓库里的 `ecosystem.config.cjs` 也可用于 PM2 常驻模式。
+- 如果你所在网络屏蔽 GitHub 22 端口，Git 远端建议改成 `ssh://git@ssh.github.com:443/<owner>/<repo>.git`，避免后续更新或提交时出现“偶发断联”。
 
 ## 分区功能说明
 

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,6 +1,7 @@
 const env = {
   UI_MODE: process.env.UI_MODE ?? "true",
   UI_PORT: process.env.UI_PORT ?? "4310",
+  UI_TIMEZONE: process.env.UI_TIMEZONE ?? "Europe/Budapest",
   READONLY_MODE: process.env.READONLY_MODE ?? "true",
   LOCAL_TOKEN_AUTH_REQUIRED: process.env.LOCAL_TOKEN_AUTH_REQUIRED ?? "true",
   MONITOR_CONTINUOUS: process.env.MONITOR_CONTINUOUS ?? "true",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-control-center",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-control-center",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.13.10",

--- a/scripts/control-center-health.sh
+++ b/scripts/control-center-health.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# OpenClaw Control Center - Health Check & Recovery Script
+# Run: watch -n 60 ./scripts/control-center-health.sh (manual watch)
+# Or: launchctl (auto-recovery via KeepAlive=true)
+
+set -euo pipefail
+
+BASE=/Users/gary/Documents/Openclaw/openclaw-control-center
+LOG=/Users/gary/.openclaw/logs/control-center-health.log
+
+GATEWAY_PORT=18789
+UI_PORT=4310
+
+timestamp() { date '+%Y-%m-%dT%H:%M:%S%z'; }
+
+echo "[$(timestamp)] 🔍 Health check starting..." >> "$LOG"
+
+# 1. Check Gateway
+if curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 http://127.0.0.1:$GATEWAY_PORT/openclaw/status 2>/dev/null | grep -q 200; then
+    echo "[$(timestamp)] ✅ Gateway (port $GATEWAY_PORT) - OK" >> "$LOG"
+else
+    echo "[$(timestamp)] ❌ Gateway DOWN - restarting..." >> "$LOG"
+    launchctl start ai.openclaw.gateway 2>/dev/null || \
+        launchctl kickstart -p gui/$(id -u)/ai.openclaw.gateway 2>/dev/null || true
+fi
+
+# 2. Check Control Center UI
+if curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 http://127.0.0.1:$UI_PORT/ 2>/dev/null | grep -q 200; then
+    echo "[$(timestamp)] ✅ Control Center (port $UI_PORT) - OK" >> "$LOG"
+else
+    echo "[$(timestamp)] ❌ Control Center DOWN - restarting..." >> "$LOG"
+    launchctl start com.gary.openclaw-control-center 2>/dev/null || \
+        launchctl kickstart -p gui/$(id -u)/com.gary.openclaw-control-center 2>/dev/null || true
+fi
+
+echo "[$(timestamp)] ✅ Health check complete" >> "$LOG"

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -1254,6 +1254,53 @@ export function startUiServer(port: number, toolClient: ToolClient, options: Sta
         });
       }
 
+      if (method === "GET" && path === "/api/staff/overview") {
+        assertAllowedQueryParams(url.searchParams, ["lang"], true);
+        const language = resolveUiLanguage(url.searchParams, "zh");
+        const snapshot = await readReadModelSnapshotWithLiveSessions(toolClient);
+        const [officeRoster, officePresence, avatarPreferences, teamSnapshot, usageCost] = await Promise.all([
+          loadBestEffortAgentRoster(),
+          loadCachedOfficeSessionPresence(),
+          loadAvatarPreferences(),
+          loadTeamSnapshot(await loadBestEffortAgentRoster(), snapshot),
+          loadCachedUsageCost(snapshot, "full"),
+        ]);
+        const usageAgentTokensByKey = new Map(
+          usageCost.breakdown.byAgent.map((item) => [normalizeLookupKey(item.key), item.tokens]),
+        );
+        const allTasks = listTasks(snapshot.tasks, projectTitleMap(snapshot));
+        const realTasks = allTasks.filter((task) => !isControlCenterMappingTask(task));
+        const officeCards = buildOfficeSpaceCards(
+          snapshot,
+          realTasks,
+          officeRoster.entries.map((entry) => entry.agentId),
+          officePresence.activeSessionsByAgent,
+          language,
+        );
+        const executionAgentSummaries = buildExecutionAgentSummaries(
+          snapshot,
+          realTasks,
+          await loadOpenclawCronCatalog(language),
+          officeRoster.entries,
+          usageAgentTokensByKey,
+        );
+        const staffOverviewCards = await buildStaffOverviewCards({
+          snapshot,
+          client: toolClient,
+          members: teamSnapshot.members,
+          officeCards,
+          executionAgentSummaries,
+          language,
+        });
+        const html = renderStaffOverviewCards(staffOverviewCards, avatarPreferences.preferences, language);
+        return writeJson(res, 200, {
+          ok: true,
+          html,
+          generatedAt: snapshot.generatedAt,
+          count: staffOverviewCards.length,
+        });
+      }
+
       if (method === "GET" && path === "/api/diagnostics") {
         assertAllowedQueryParams(url.searchParams, ["format"], true);
         const format = normalizeQueryString(url.searchParams.get("format"), "format", 16, true);
@@ -7279,7 +7326,7 @@ async function renderHtml(
         </div>
         <button type="button" class="btn section-refresh-btn" id="staff-status-refresh-inline">${escapeHtml(t("Refresh live status", "刷新实时状态"))}</button>
       </div>
-      ${staffOverviewCardsHtml}
+      <div id="staff-overview-cards" data-staff-overview-root="1">${staffOverviewCardsHtml}</div>
     </section>
     <details class="card compact-details">
       <summary>${escapeHtml(t("Shared staff mission", "员工共同目标"))}</summary>
@@ -15962,7 +16009,37 @@ function renderHeaderControlsScript(language: UiLanguage = "zh"): string {
       document.getElementById('staff-status-refresh-inline')
     ].filter(Boolean);
     staffRefreshButtons.forEach((button) => {
-      button.addEventListener('click', () => triggerRefresh(button));
+      button.addEventListener('click', async () => {
+        const staffRoot = document.getElementById('staff-overview-cards');
+        const htmlRoot = document.documentElement;
+        const lang = (htmlRoot && htmlRoot.getAttribute('lang')) || 'zh';
+        if (!staffRoot) {
+          triggerRefresh(button);
+          return;
+        }
+        try {
+          button.setAttribute('aria-busy', 'true');
+        } catch {}
+        try {
+          const response = await fetch('/api/staff/overview?lang=' + encodeURIComponent(lang), {
+            headers: { 'Accept': 'application/json' },
+            cache: 'no-store'
+          });
+          if (!response.ok) throw new Error('staff overview refresh failed');
+          const payload = await response.json();
+          if (!payload || payload.ok !== true || typeof payload.html !== 'string') {
+            throw new Error('invalid staff overview payload');
+          }
+          staffRoot.innerHTML = payload.html;
+        } catch (error) {
+          triggerRefresh(button);
+          return;
+        } finally {
+          try {
+            button.removeAttribute('aria-busy');
+          } catch {}
+        }
+      });
     });
   };
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -5878,7 +5878,7 @@ async function renderHtml(
   const usageCostMode: UsageCostMode = "full";
   const sectionMeta = sectionLinks.find((item) => item.key === activeSection) ?? sectionLinks[0];
   const collaborationImmersive = false;
-  const isStaffSection = activeSection === "team";
+
   const sectionTitle = resolveDashboardSectionTitle(sectionMeta, options.language);
   const sectionLeadText =
     activeSection === "overview"
@@ -11428,7 +11428,6 @@ async function renderHtml(
           <div class="section-blurb">${escapeHtml(sectionLeadText)}</div>
         </div>
         <div class="section-head-actions">
-          ${isStaffSection ? `<button type="button" class="btn section-top-refresh-btn" id="staff-status-refresh">${escapeHtml(t("Refresh live status", "刷新实时状态"))}</button>` : ""}
           <button id="inspector-toggle" type="button" class="panel-toggle" aria-pressed="false">${escapeHtml(t("Collapse inspector", "收起检视栏"))}</button>
         </div>
       </header>
@@ -16005,7 +16004,6 @@ function renderHeaderControlsScript(language: UiLanguage = "zh"): string {
     }
 
     const staffRefreshButtons = [
-      document.getElementById('staff-status-refresh'),
       document.getElementById('staff-status-refresh-inline')
     ].filter(Boolean);
     staffRefreshButtons.forEach((button) => {

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -5831,6 +5831,7 @@ async function renderHtml(
   const usageCostMode: UsageCostMode = "full";
   const sectionMeta = sectionLinks.find((item) => item.key === activeSection) ?? sectionLinks[0];
   const collaborationImmersive = false;
+  const isStaffSection = activeSection === "team";
   const sectionTitle = resolveDashboardSectionTitle(sectionMeta, options.language);
   const sectionLeadText =
     activeSection === "overview"
@@ -7276,7 +7277,7 @@ async function renderHtml(
           <h2>${escapeHtml(t("Staff overview", "员工总览"))}</h2>
           <div class="meta">${escapeHtml(t("The default view shows only name, role, current status, current work, recent output, and whether each person is on the schedule.", "默认视图只显示员工名字、角色定位、当前状态、正在处理什么、最近产出，以及是否在排班里。"))}</div>
         </div>
-        <button type="button" class="btn section-refresh-btn" id="staff-status-refresh">${escapeHtml(t("Refresh live status", "刷新实时状态"))}</button>
+        <button type="button" class="btn section-refresh-btn" id="staff-status-refresh-inline">${escapeHtml(t("Refresh live status", "刷新实时状态"))}</button>
       </div>
       ${staffOverviewCardsHtml}
     </section>
@@ -11380,6 +11381,7 @@ async function renderHtml(
           <div class="section-blurb">${escapeHtml(sectionLeadText)}</div>
         </div>
         <div class="section-head-actions">
+          ${isStaffSection ? `<button type="button" class="btn section-top-refresh-btn" id="staff-status-refresh">${escapeHtml(t("Refresh live status", "刷新实时状态"))}</button>` : ""}
           <button id="inspector-toggle" type="button" class="panel-toggle" aria-pressed="false">${escapeHtml(t("Collapse inspector", "收起检视栏"))}</button>
         </div>
       </header>
@@ -15955,10 +15957,13 @@ function renderHeaderControlsScript(language: UiLanguage = "zh"): string {
       refreshButton.addEventListener('click', () => triggerRefresh(refreshButton));
     }
 
-    const staffRefreshButton = document.getElementById('staff-status-refresh');
-    if (staffRefreshButton) {
-      staffRefreshButton.addEventListener('click', () => triggerRefresh(staffRefreshButton));
-    }
+    const staffRefreshButtons = [
+      document.getElementById('staff-status-refresh'),
+      document.getElementById('staff-status-refresh-inline')
+    ].filter(Boolean);
+    staffRefreshButtons.forEach((button) => {
+      button.addEventListener('click', () => triggerRefresh(button));
+    });
   };
 
   const captureState = () => {

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -16029,6 +16029,13 @@ function renderHeaderControlsScript(language: UiLanguage = "zh"): string {
             throw new Error('invalid staff overview payload');
           }
           staffRoot.innerHTML = payload.html;
+          // Re-initialize pixel avatars after DOM swap
+          const fa = Array.from(staffRoot.querySelectorAll('.staff-avatar[data-agent-id]'));
+          fa.forEach(function(av) {
+            if (window.__openclawPixelAvatar && typeof window.__openclawPixelAvatar.registerElement === 'function') {
+              window.__openclawPixelAvatar.registerElement(av);
+            }
+          });
         } catch (error) {
           triggerRefresh(button);
           return;
@@ -17695,6 +17702,18 @@ function renderAgentVisualEnhancerScript(): string {
         if (!actor.disabled) {
           render(actor.canvas, actor.animal, actor.accent, { bob: 0, sway: 0, blink: 0 });
         }
+      },
+      registerElement: (avatarEl) => {
+        if (!avatarEl) return;
+        const canvas = avatarEl.querySelector && avatarEl.querySelector(".agent-pixel-canvas");
+        if (!canvas) return;
+        const existing = motionActors.find((item) => item.canvas === canvas);
+        if (existing) return;
+        const accent = getComputedStyle(avatarEl).getPropertyValue("--agent-accent").trim() || "#4e79a7";
+        const animal = (avatarEl.dataset && avatarEl.dataset.animal ? avatarEl.dataset.animal : "default");
+        const seed = hashSeed(animal + ":" + accent + ":" + String(motionActors.length + 1));
+        motionActors.push({ canvas, accent, animal, seed, disabled: false });
+        render(canvas, animal.trim().toLowerCase(), accent, { bob: 0, sway: 0, blink: 0 });
       },
     };
   } catch {}

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -7271,8 +7271,13 @@ async function renderHtml(
   });
   const teamSection = activeSection === "team" ? `
     <section class="card">
-      <h2>${escapeHtml(t("Staff overview", "员工总览"))}</h2>
-      <div class="meta">${escapeHtml(t("The default view shows only name, role, current status, current work, recent output, and whether each person is on the schedule.", "默认视图只显示员工名字、角色定位、当前状态、正在处理什么、最近产出，以及是否在排班里。"))}</div>
+      <div class="section-inline-head">
+        <div>
+          <h2>${escapeHtml(t("Staff overview", "员工总览"))}</h2>
+          <div class="meta">${escapeHtml(t("The default view shows only name, role, current status, current work, recent output, and whether each person is on the schedule.", "默认视图只显示员工名字、角色定位、当前状态、正在处理什么、最近产出，以及是否在排班里。"))}</div>
+        </div>
+        <button type="button" class="btn section-refresh-btn" id="staff-status-refresh">${escapeHtml(t("Refresh live status", "刷新实时状态"))}</button>
+      </div>
       ${staffOverviewCardsHtml}
     </section>
     <details class="card compact-details">
@@ -9196,6 +9201,17 @@ async function renderHtml(
       box-shadow: var(--ring-soft), inset 0 1px 0 rgba(255, 255, 255, 0.84);
     }
     .filter-actions { margin-top: 8px; display: flex; gap: 10px; align-items: center; }
+    .section-inline-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 10px;
+    }
+    .section-refresh-btn {
+      flex: 0 0 auto;
+      white-space: nowrap;
+    }
     .btn {
       -webkit-appearance: none;
       appearance: none;
@@ -11294,6 +11310,8 @@ async function renderHtml(
       .overview-action-grid { grid-template-columns: 1fr; }
       .overview-task-strip { flex-direction: column; }
       .overview-quick-links { justify-content: flex-start; min-width: 0; }
+      .section-inline-head { flex-direction: column; align-items: stretch; }
+      .section-refresh-btn { width: 100%; }
       .task-hub-stat-grid { grid-template-columns: 1fr; }
       .task-hub-shell { grid-template-columns: 1fr; }
       .task-hub-grid { grid-template-columns: 1fr; }
@@ -15923,15 +15941,23 @@ function renderHeaderControlsScript(language: UiLanguage = "zh"): string {
   }
 
   const setupRefreshButton = () => {
+    const triggerRefresh = (button) => {
+      if (!button) return;
+      try {
+        button.setAttribute('aria-busy', 'true');
+      } catch {}
+      try { window.sessionStorage.setItem(restoreKey, JSON.stringify(captureState())); } catch {}
+      window.setTimeout(() => location.reload(), 60);
+    };
+
     const refreshButton = document.getElementById('data-refresh');
     if (refreshButton) {
-      refreshButton.addEventListener('click', () => {
-        try {
-          refreshButton.setAttribute('aria-busy', 'true');
-        } catch {}
-        try { window.sessionStorage.setItem(restoreKey, JSON.stringify(captureState())); } catch {}
-        window.setTimeout(() => location.reload(), 60);
-      });
+      refreshButton.addEventListener('click', () => triggerRefresh(refreshButton));
+    }
+
+    const staffRefreshButton = document.getElementById('staff-status-refresh');
+    if (staffRefreshButton) {
+      staffRefreshButton.addEventListener('click', () => triggerRefresh(staffRefreshButton));
     }
   };
 


### PR DESCRIPTION
## Summary
Optimize openclaw-control-center for macOS local resident deployment and improve the staff page experience.
## Changes
1. **Launchd integration** — Auto-start & crash recovery via macOS `launchd` plist.
2. **SSH port 443 support** — Git remote configured for `ssh://git@ssh.github.com:443` to bypass port 22 blocking.
3. **Staff page "Refresh live status" button** — Single button inside the staff overview card area.
4. **Partial staff refresh (no full page reload)** — New `/api/staff/overview` endpoint returns fresh staff card HTML. Click triggers AJAX fetch → swaps only `#staff-overview-cards` region.
5. **Pixel avatar animation preserved after partial refresh** — Fixed bug where agent canvas animations stopped after partial DOM swap. Added `registerElement()` to the avatar motion engine so new canvas elements rejoin the animation loop.
6. **Health check script** — `scripts/control-center-health.sh` monitors both gateway & control center.
## Related files
- `ecosystem.config.cjs` — PM2 config with UI_TIMEZONE
- `scripts/control-center-health.sh` — Health check script
- `README.zh-CN.md` — Deployment notes (launchd, SSH 443, restart on code change)