### PR TITLE
Add MiniMax context metadata

### DIFF
--- a/src/runtime/usage-cost.ts
+++ b/src/runtime/usage-cost.ts
@@ -199,6 +199,19 @@ interface ModelContextCatalogEntry {
   provider?: string;
 }
 
+const BUILT_IN_MODEL_CONTEXT_CATALOG: readonly ModelContextCatalogEntry[] = [
+  {
+    match: "minimax-m3",
+    contextWindowTokens: 1_000_000,
+    provider: "MiniMax",
+  },
+  {
+    match: "minimax-m2.7",
+    contextWindowTokens: 204_800,
+    provider: "MiniMax",
+  },
+];
+
 interface RuntimeSessionContext {
   sessionKey: string;
   sessionId?: string;
@@ -646,10 +659,22 @@ async function loadModelContextCatalog(): Promise<ModelContextCatalogEntry[]> {
         provider: provider || undefined,
       });
     }
-    return entries;
+    return mergeModelContextCatalog(entries);
   } catch {
-    return [];
+    return mergeModelContextCatalog([]);
   }
+}
+
+function mergeModelContextCatalog(entries: ModelContextCatalogEntry[]): ModelContextCatalogEntry[] {
+  const configuredMatches = new Set(entries.map((entry) => entry.match));
+  return [
+    ...entries,
+    ...BUILT_IN_MODEL_CONTEXT_CATALOG.filter((entry) => !configuredMatches.has(entry.match)),
+  ];
+}
+
+export function getBuiltInModelContextCatalogForSmoke(): ModelContextCatalogEntry[] {
+  return BUILT_IN_MODEL_CONTEXT_CATALOG.map((entry) => ({ ...entry }));
 }
 
 async function loadOpenclawCronJobNameMap(): Promise<Map<string, string>> {

--- a/test/usage-cost.test.ts
+++ b/test/usage-cost.test.ts
@@ -51,6 +51,29 @@ test("usage-cost snapshot computes context percent and burn-rate status when sou
   assert.equal(usage.periods.find((item) => item.key === "today")?.sourceStatus, "connected");
 });
 
+test("usage-cost built-in catalog resolves current MiniMax context windows", async () => {
+  const { computeUsageCostSnapshot, getBuiltInModelContextCatalogForSmoke } = await import(
+    "../src/runtime/usage-cost"
+  );
+  const catalog = getBuiltInModelContextCatalogForSmoke();
+  const cases = [
+    { model: "MiniMax-M3", contextWindowTokens: 1_000_000 },
+    { model: "MiniMax-M2.7", contextWindowTokens: 204_800 },
+  ];
+
+  for (const item of cases) {
+    const usage = computeUsageCostSnapshot(
+      buildSnapshotFixture({ model: item.model }),
+      [],
+      catalog,
+    );
+
+    assert.equal(usage.contextWindows[0]?.contextLimitTokens, item.contextWindowTokens);
+    assert.equal(usage.contextWindows[0]?.provider, "MiniMax");
+    assert.equal(usage.contextWindows[0]?.dataStatus, "connected");
+  }
+});
+
 test("usage-cost snapshot uses runtime session events for real requests, trends, and breakdown rows", async () => {
   const { computeUsageCostSnapshot } = await import("../src/runtime/usage-cost");
   const snapshot = buildSnapshotFixture({


### PR DESCRIPTION
Reason: Add current MiniMax context-window metadata for context-pressure reporting.

Changes:
- add built-in context metadata for MiniMax-M3 and MiniMax-M2.7
- merge built-in entries with optional runtime catalog overrides
- cover built-in model resolution in usage-cost tests

Checks:
- `git diff --check origin/main..HEAD`
- committed diff secret scan
